### PR TITLE
Move shortlinks to fsektionen.se/l/*

### DIFF
--- a/app/views/short_links/index.html.haml
+++ b/app/views/short_links/index.html.haml
@@ -15,7 +15,7 @@
   %tbody
     - @short_links.each do |sl|
       %tr
-        %td= sl.link
+        %td= 'fsektionen.se/l/'+ sl.link
         %td= link_to sl.target, sl.target
         %td= link_to 'Ta bort', sl, :method => :delete
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,5 +150,5 @@ Fsek::Application.routes.draw do
 
   # Catch-all for short links.
   # This must be at the bottom!
-  get '*link' => 'short_links#go'
+  get '/l/*link' => 'short_links#go'
 end


### PR DESCRIPTION
1. FooBar creates the shortlink fsektionen.se/foo => foo.com
2. We introduce the FooController at /foo
3. FooBar's link stops working

In this PR links are rooted at fsektionen.se/l/ so this is not a problem.