### PR TITLE
Add profile fields to User model

### DIFF
--- a/db/migrate/20150425064439_add_profile_fields_to_user.rb
+++ b/db/migrate/20150425064439_add_profile_fields_to_user.rb
@@ -1,79 +1,37 @@
 class AddProfileFieldsToUser < ActiveRecord::Migration
   def change
-    copy_posts_profiles_to_posts_users
+    # Create new join table
+    create_table :post_users do |t|
+      t.integer :post_id
+      t.integer :user_id
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
 
-    # Add user_id and set it based on profile_id
+    add_index :post_users, :post_id
+    add_index :post_users, :user_id
+
+    # Add user_id
     update_tables :cafe_works, :rents, :candidates, :documents, :news
 
     # Extend users with columns from profile
     add_column :users, :firstname, :string
-    add_column :users, :start_year, :integer
+    add_column :users, :lastname, :string
+    add_column :users, :phone, :string
+    add_column :users, :stil_id, :string
+    add_column :users, :first_post_id, :integer
     add_column :users, :avatar_file_name, :string
     add_column :users, :avatar_content_type, :string
     add_column :users, :avatar_file_size, :integer
     add_column :users, :avatar_updated_at, :datetime
-    add_column :users, :first_post, :integer
-    add_column :users, :stil_id, :string
-    add_column :users, :phone, :string
-    add_column :users, :lastname, :string
+    add_column :users, :start_year, :integer
+    add_column :users, :program, :string
 
-    copy_profiles_data_into_users
-  end
-
-  def copy_profiles_data_into_users
-    ActiveRecord::Base.connection.execute <<-eof
-      update users u
-      join profiles p on p.user_id = u.id
-      set
-          u.firstname = p.name, -- note changed column name!
-          u.start_year = p.start_year,
-          u.avatar_file_name = p.avatar_file_name,
-          u.avatar_content_type = p.avatar_content_type,
-          u.avatar_file_size = p.avatar_file_size,
-          u.avatar_updated_at = p.avatar_updated_at,
-          u.first_post = p.first_post,
-          u.stil_id = p.stil_id,
-          u.phone = p.phone,
-          u.lastname = p.lastname
-    eof
-  end
-
-  def copy_posts_profiles_to_posts_users
-     reversible do |dir|
-      dir.up do
-        ActiveRecord::Base.connection.execute <<-eof
-          create table posts_users like posts_profiles
-        eof
-      end
-      dir.down do
-        drop_table :posts_users
-      end
-    end
   end
 
   def update_tables(*tables)
     tables.each do |table|
       add_column table, :user_id, :integer
-      copy_user_id_from_profile_id_for table
-    end
-  end
-
-  def copy_user_id_from_profile_id_for(table)
-    reversible do |dir|
-      dir.up do
-        ActiveRecord::Base.connection.execute <<-eof
-          update #{table} t
-          join profiles p on t.user_id = p.id
-          set t.user_id = p.user_id
-        eof
-      end
-      dir.down do
-        ActiveRecord::Base.connection.execute <<-eof
-          update profiles p
-          join #{table} t on p.id = t.user_id
-          set p.user_id = t.user_id
-        eof
-      end
     end
   end
 end

--- a/db/migrate/20150425064439_add_profile_fields_to_user.rb
+++ b/db/migrate/20150425064439_add_profile_fields_to_user.rb
@@ -1,0 +1,79 @@
+class AddProfileFieldsToUser < ActiveRecord::Migration
+  def change
+    copy_posts_profiles_to_posts_users
+
+    # Add user_id and set it based on profile_id
+    update_tables :cafe_works, :rents, :candidates, :documents, :news
+
+    # Extend users with columns from profile
+    add_column :users, :firstname, :string
+    add_column :users, :start_year, :integer
+    add_column :users, :avatar_file_name, :string
+    add_column :users, :avatar_content_type, :string
+    add_column :users, :avatar_file_size, :integer
+    add_column :users, :avatar_updated_at, :datetime
+    add_column :users, :first_post, :integer
+    add_column :users, :stil_id, :string
+    add_column :users, :phone, :string
+    add_column :users, :lastname, :string
+
+    copy_profiles_data_into_users
+  end
+
+  def copy_profiles_data_into_users
+    ActiveRecord::Base.connection.execute <<-eof
+      update users u
+      join profiles p on p.user_id = u.id
+      set
+          u.firstname = p.name, -- note changed column name!
+          u.start_year = p.start_year,
+          u.avatar_file_name = p.avatar_file_name,
+          u.avatar_content_type = p.avatar_content_type,
+          u.avatar_file_size = p.avatar_file_size,
+          u.avatar_updated_at = p.avatar_updated_at,
+          u.first_post = p.first_post,
+          u.stil_id = p.stil_id,
+          u.phone = p.phone,
+          u.lastname = p.lastname
+    eof
+  end
+
+  def copy_posts_profiles_to_posts_users
+     reversible do |dir|
+      dir.up do
+        ActiveRecord::Base.connection.execute <<-eof
+          create table posts_users like posts_profiles
+        eof
+      end
+      dir.down do
+        drop_table :posts_users
+      end
+    end
+  end
+
+  def update_tables(*tables)
+    tables.each do |table|
+      add_column table, :user_id, :integer
+      copy_user_id_from_profile_id_for table
+    end
+  end
+
+  def copy_user_id_from_profile_id_for(table)
+    reversible do |dir|
+      dir.up do
+        ActiveRecord::Base.connection.execute <<-eof
+          update #{table} t
+          join profiles p on t.user_id = p.id
+          set t.user_id = p.user_id
+        eof
+      end
+      dir.down do
+        ActiveRecord::Base.connection.execute <<-eof
+          update profiles p
+          join #{table} t on p.id = t.user_id
+          set p.user_id = t.user_id
+        eof
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -313,6 +313,16 @@ ActiveRecord::Schema.define(version: 20150425064439) do
     t.datetime "updated_at"
   end
 
+  create_table "post_users", force: :cascade do |t|
+    t.integer  "post_id",    limit: 4
+    t.integer  "user_id",    limit: 4
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "post_users", ["post_id"], name: "index_post_users_on_post_id", using: :btree
+  add_index "post_users", ["user_id"], name: "index_post_users_on_user_id", using: :btree
+
   create_table "posts", force: :cascade do |t|
     t.string   "title",         limit: 255
     t.integer  "limit",         limit: 4,     default: 0
@@ -330,11 +340,6 @@ ActiveRecord::Schema.define(version: 20150425064439) do
   end
 
   create_table "posts_profiles", id: false, force: :cascade do |t|
-    t.integer "post_id",    limit: 4
-    t.integer "profile_id", limit: 4
-  end
-
-  create_table "posts_users", id: false, force: :cascade do |t|
     t.integer "post_id",    limit: 4
     t.integer "profile_id", limit: 4
   end
@@ -372,7 +377,7 @@ ActiveRecord::Schema.define(version: 20150425064439) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "comment",     limit: 65535
-    t.string   "status",      limit: 255,   default: "Ej bestämd"
+    t.string   "status",      limit: 255,   default: "Ej bestÃƒÂ¤md"
     t.boolean  "service",     limit: 1,     default: false
     t.string   "access_code", limit: 255
     t.integer  "user_id",     limit: 4
@@ -416,15 +421,16 @@ ActiveRecord::Schema.define(version: 20150425064439) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "firstname",              limit: 255
-    t.integer  "start_year",             limit: 4
+    t.string   "lastname",               limit: 255
+    t.string   "phone",                  limit: 255
+    t.string   "stil_id",                limit: 255
+    t.integer  "first_post_id",          limit: 4
     t.string   "avatar_file_name",       limit: 255
     t.string   "avatar_content_type",    limit: 255
     t.integer  "avatar_file_size",       limit: 4
     t.datetime "avatar_updated_at"
-    t.integer  "first_post",             limit: 4
-    t.string   "stil_id",                limit: 255
-    t.string   "phone",                  limit: 255
-    t.string   "lastname",               limit: 255
+    t.integer  "start_year",             limit: 4
+    t.string   "program",                limit: 255
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150331104940) do
+ActiveRecord::Schema.define(version: 20150425064439) do
 
   create_table "album_categories", force: :cascade do |t|
     t.string   "name",       limit: 255
@@ -39,14 +39,6 @@ ActiveRecord::Schema.define(version: 20150331104940) do
     t.string   "category",          limit: 255
     t.integer  "photo_category_id", limit: 4
   end
-
-  create_table "albums_categories", id: false, force: :cascade do |t|
-    t.integer "album_id",    limit: 4
-    t.integer "category_id", limit: 4
-  end
-
-  add_index "albums_categories", ["album_id", "category_id"], name: "index_albums_categories_on_album_id_and_category_id", unique: true, using: :btree
-  add_index "albums_categories", ["category_id"], name: "index_albums_categories_on_category_id", using: :btree
 
   create_table "albums_images", id: false, force: :cascade do |t|
     t.integer "album_id", limit: 4
@@ -80,11 +72,7 @@ ActiveRecord::Schema.define(version: 20150331104940) do
     t.integer  "d_year",       limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-  end
-
-  create_table "cafe_works_councils", id: false, force: :cascade do |t|
-    t.integer "cafe_work_id", limit: 4
-    t.integer "council_id",   limit: 4
+    t.integer  "user_id",      limit: 4
   end
 
   create_table "candidates", force: :cascade do |t|
@@ -99,19 +87,11 @@ ActiveRecord::Schema.define(version: 20150331104940) do
     t.string   "phone",       limit: 255
     t.string   "name",        limit: 255
     t.string   "lastname",    limit: 255
+    t.integer  "user_id",     limit: 4
   end
 
   add_index "candidates", ["post_id"], name: "index_candidates_on_post_id", using: :btree
   add_index "candidates", ["profile_id"], name: "index_candidates_on_profile_id", using: :btree
-
-  create_table "categories", force: :cascade do |t|
-    t.string   "title",       limit: 255
-    t.text     "description", limit: 65535
-    t.string   "typ",         limit: 255
-    t.boolean  "sub",         limit: 1,     default: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
 
   create_table "constants", force: :cascade do |t|
     t.string   "name",       limit: 255
@@ -158,6 +138,7 @@ ActiveRecord::Schema.define(version: 20150331104940) do
     t.integer  "profile_id",       limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "user_id",          limit: 4
   end
 
   create_table "elections", force: :cascade do |t|
@@ -183,25 +164,6 @@ ActiveRecord::Schema.define(version: 20150331104940) do
   create_table "elections_posts", id: false, force: :cascade do |t|
     t.integer "election_id", limit: 4
     t.integer "post_id",     limit: 4
-  end
-
-  create_table "email_accounts", force: :cascade do |t|
-    t.integer  "profile_id", limit: 4
-    t.string   "email",      limit: 255
-    t.string   "title",      limit: 255
-    t.boolean  "active",     limit: 1
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "emails", force: :cascade do |t|
-    t.integer  "email_account_id", limit: 4
-    t.string   "receiver",         limit: 255
-    t.string   "subject",          limit: 255
-    t.text     "message",          limit: 65535
-    t.boolean  "copy",             limit: 1
-    t.datetime "created_at"
-    t.datetime "updated_at"
   end
 
   create_table "events", force: :cascade do |t|
@@ -245,16 +207,6 @@ ActiveRecord::Schema.define(version: 20150331104940) do
     t.integer  "subcategory_id",    limit: 4
   end
 
-  create_table "lists", force: :cascade do |t|
-    t.string   "category",   limit: 255
-    t.string   "name",       limit: 255
-    t.string   "string1",    limit: 255
-    t.integer  "int1",       limit: 4
-    t.boolean  "bool1",      limit: 1
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "menus", force: :cascade do |t|
     t.string   "location",   limit: 255
     t.integer  "index",      limit: 4
@@ -278,6 +230,7 @@ ActiveRecord::Schema.define(version: 20150331104940) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "profile_id",         limit: 4
+    t.integer  "user_id",            limit: 4
   end
 
   create_table "nominations", force: :cascade do |t|
@@ -360,21 +313,6 @@ ActiveRecord::Schema.define(version: 20150331104940) do
     t.datetime "updated_at"
   end
 
-  create_table "phrasing_phrase_versions", force: :cascade do |t|
-    t.integer  "phrasing_phrase_id", limit: 4
-    t.text     "value",              limit: 65535
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "phrasing_phrases", force: :cascade do |t|
-    t.string   "locale",     limit: 255
-    t.string   "key",        limit: 255
-    t.text     "value",      limit: 65535
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "posts", force: :cascade do |t|
     t.string   "title",         limit: 255
     t.integer  "limit",         limit: 4,     default: 0
@@ -392,6 +330,11 @@ ActiveRecord::Schema.define(version: 20150331104940) do
   end
 
   create_table "posts_profiles", id: false, force: :cascade do |t|
+    t.integer "post_id",    limit: 4
+    t.integer "profile_id", limit: 4
+  end
+
+  create_table "posts_users", id: false, force: :cascade do |t|
     t.integer "post_id",    limit: 4
     t.integer "profile_id", limit: 4
   end
@@ -432,10 +375,8 @@ ActiveRecord::Schema.define(version: 20150331104940) do
     t.string   "status",      limit: 255,   default: "Ej bestämd"
     t.boolean  "service",     limit: 1,     default: false
     t.string   "access_code", limit: 255
+    t.integer  "user_id",     limit: 4
   end
-
-  add_index "rents", ["d_from"], name: "index_rents_on_d_from", using: :btree
-  add_index "rents", ["d_til"], name: "index_rents_on_d_til", using: :btree
 
   create_table "roles", force: :cascade do |t|
     t.string   "name",        limit: 255,   null: false
@@ -474,6 +415,16 @@ ActiveRecord::Schema.define(version: 20150331104940) do
     t.integer  "role_id",                limit: 4,   default: 2,  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "firstname",              limit: 255
+    t.integer  "start_year",             limit: 4
+    t.string   "avatar_file_name",       limit: 255
+    t.string   "avatar_content_type",    limit: 255
+    t.integer  "avatar_file_size",       limit: 4
+    t.datetime "avatar_updated_at"
+    t.integer  "first_post",             limit: 4
+    t.string   "stil_id",                limit: 255
+    t.string   "phone",                  limit: 255
+    t.string   "lastname",               limit: 255
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
This is a reversible migration which

1. Adds user_id to all models currently using profile_id
2. Sets the user_id field based on a join on the profile_id field
3. Adds profile fields to the user model
4. Sets the profile fields based on how the Profile model looks like

Good thing: This does not break anything. We can merge it asap.

We need to re-run the data migration again later as there may be some additions of data between the PRs.

I will take responsibility for changing PR #109 is compatible.