### PR TITLE
Circle: remove master deploy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,9 @@ deployment:
     branch: stage
     commands:
       - bundle exec cap staging deploy
-  production:
-    branch: master
 
 database:
   override:
     - cp config/secrets.yml.template config/secrets.yml
     - cp config/database.yml.circle config/database.yml
-    - bundle exec rake db:create db:migrate db:populate_test permissions:load --trace
+    - bundle exec rake db:create db:migrate permissions:load db:populate_test --trace


### PR DESCRIPTION
Left the deploy-section for master without any commands, error showed when deploying to production.
