### PR TITLE
Adding rbenv_path to Capistrano setup, issues after updating gems

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,6 +5,7 @@ set :application, 'fsek'
 set :scm, :git
 set :repo_url, 'https://github.com/fsek/web.git'
 set :stages, %w(staging production development)
+set :rbenv_path, '$HOME/.rbenv'
 
 set :user, :dirac
 


### PR DESCRIPTION
#279 couldn't be deployed as because of an error

http://stackoverflow.com/questions/34126546/rbenv-version-2-2-3-is-not-installed-set-by-rbenv-version-environment-variab

Adding a specific `rbenv_path` should help.