### PR TITLE
Resolve redirect after Event create

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -21,7 +21,7 @@ class Admin::EventsController < ApplicationController
     @event = Event.new(event_params)
     @event.author = current_user
     if @event.save
-      redirect_to admin_event_path(@event), notice: alert_create(Event)
+      redirect_to edit_admin_event_path(@event), notice: alert_create(Event)
     else
       @tab = :info
       render :new, status: 422

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Admin::EventsController, type: :controller do
         post :create, event: attributes_for(:event)
       end.should change(Event, :count).by(1)
 
-      response.should redirect_to([:admin, Event.last])
+      response.should redirect_to(edit_admin_event_path(Event.last))
     end
 
     it 'invalid parameters' do


### PR DESCRIPTION
The test for and the controller for the `#create` action did not redirect to the correct path.