### PR TITLE
Removing redirect from '/kontakt' to '/kontakter'

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,9 +132,6 @@ Fsek::Application.routes.draw do
       post :mail, on: :member
     end
 
-    get '/kontakt', to: redirect('/kontakter')
-    get '/kontakt/:id', to: redirect('/kontakter/%{id}')
-
     resources :calendars, path: :kalender,  only: :index do
       get :export, on: :collection
     end


### PR DESCRIPTION
The menu is fixed, so this redirect is no longer required :)