### PR TITLE
Capistrano config: run tasks after deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,4 +18,6 @@ set :linked_files, %w{config/database.yml config/secrets.yml}
 # Default value for linked_dirs is []
 set :linked_dirs, %w{log tmp vendor/bundle public/system public/uploads storage public/sitemaps}
 
-after 'deploy:publishing', 'passenger:restart', 'deploy:sitemap:refresh'
+after 'deploy:publishing', 'passenger:restart'
+after 'deploy:publishing', 'deploy:sitemap:refresh'
+after 'deploy:publishing', 'deploy:permissions:load'


### PR DESCRIPTION
Now running sitemap generation and `permissions:load` properly.
Tested on stage.

Fixing #345 