### PR TITLE
Nomination: validate email format

### DIFF
--- a/app/models/nomination.rb
+++ b/app/models/nomination.rb
@@ -4,6 +4,8 @@ class Nomination < ActiveRecord::Base
   belongs_to :post
 
   validates :name, :email, :post_id, presence: true
+  validates :email, format: { with: /\A.+@.+\..+\z/i,
+                              message: I18n.t('nomination.invalid_email') }
 
   after_create :send_email
 
@@ -12,6 +14,6 @@ class Nomination < ActiveRecord::Base
   end
 
   def candidate_url
-    Rails.application.routes.url_helpers.new_candidate_url(host: PUBLIC_URL)
+    Rails.application.routes.url_helpers.new_candidate_url(post: post, host: PUBLIC_URL)
   end
 end

--- a/config/locales/models/nomination.sv.yml
+++ b/config/locales/models/nomination.sv.yml
@@ -13,3 +13,5 @@ sv:
         motivation: Motivering
         phone: Telefon
         stil_id: Stil-id
+  nomination:
+    invalid_email: E-postadressen har inte giltligt format.

--- a/spec/models/nomination_spec.rb
+++ b/spec/models/nomination_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Nomination, type: :model do
+  describe 'validations' do
+    it 'checks presence of name' do
+      nomination = Nomination.new
+
+      nomination.should validate_presence_of(:name)
+    end
+
+    it 'checks presence of email' do
+      nomination = Nomination.new
+
+      nomination.should validate_presence_of(:email)
+    end
+
+    it 'checks presence of post_id' do
+      nomination = Nomination.new
+
+      nomination.should validate_presence_of(:post_id)
+    end
+
+    it 'checks email format' do
+      nomination = Nomination.new
+
+      nomination.should allow_value('hilbert911.1@fsektionen.se').for(:email)
+      nomination.should_not allow_value('hilbert').for(:email)
+      nomination.should_not allow_value('hilbert@fsektionen').for(:email)
+      nomination.should_not allow_value('@fsektionen.se').for(:email)
+    end
+  end
+
+  describe 'public methods' do
+    it 'has candidate_url' do
+      nomination = build_stubbed(:nomination)
+      post = nomination.post
+
+      nomination.candidate_url.should eq(new_candidate_url(post: post.id, host: PUBLIC_URL))
+    end
+  end
+end


### PR DESCRIPTION
Added spec for Nomination model
Adding validation on email format, based the regex on:
https://davidcel.is/posts/stop-validating-email-addresses-with-regex/