### PR TITLE
News: changing categories in form

### DIFF
--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -20,7 +20,7 @@ class Admin::NewsController < Admin::BaseController
     @news = News.new(news_params)
     @news.user = current_user
     if @news.save
-      redirect_to news_path(@news), notice: alert_create(News)
+      redirect_to edit_admin_news_path(@news), notice: alert_create(News)
     else
       render :new, status: 422
     end
@@ -29,7 +29,7 @@ class Admin::NewsController < Admin::BaseController
   def update
     @news = News.find(params[:id])
     if @news.update(news_params)
-      redirect_to news_path(@news), notice: alert_update(News)
+      redirect_to edit_admin_news_path(@news), notice: alert_update(News)
     else
       render :edit, status: 422
     end

--- a/app/views/admin/news/_form.html.erb
+++ b/app/views/admin/news/_form.html.erb
@@ -2,13 +2,20 @@
   <%= f.input :title %>
   <%= f.input :content, as: :pagedown, input_html: { preview: true, rows: 10 } %>
   <%= f.input :url %>
-  <%= f.association :categories, collection: Category.all,
-                                 input_html: { class: 'select2' } %>
+
+
   <% if news.image.present? %>
     <%= image_tag(news.thumb) %>
     <%= f.input :remove_image, as: :boolean %>
   <% else %>
     <%= f.input :image, as: :file %>
+  <% end %>
+
+  <% if news.persisted? %>
+    <%= f.association :categories, collection: Category.all,
+                                   input_html: { class: 'select2' } %>
+  <% else %>
+    <p><%= t('.categories_after_save') %></p>
   <% end %>
   <%= f.button :submit %>
 

--- a/config/locales/views/admin/news/news.sv.yml
+++ b/config/locales/views/admin/news/news.sv.yml
@@ -1,0 +1,5 @@
+sv:
+  admin:
+    news:
+      form:
+        categories_after_save: Kategorier kan läggas till efter att nyheten sparas.

--- a/spec/controllers/admin/news_controller_spec.rb
+++ b/spec/controllers/admin/news_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Admin::NewsController, type: :controller do
         post :create, news: attributes_for(:news)
       end.should change(News, :count).by(1)
 
-      response.should redirect_to(News.last)
+      response.should redirect_to(edit_admin_news_path(News.last))
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe Admin::NewsController, type: :controller do
       patch :update, id: news.to_param, news: { title: 'Hej' }
       news.reload
       news.title.should eq('Hej')
-      response.should redirect_to(news)
+      response.should redirect_to(edit_admin_news_path(news))
     end
   end
 end


### PR DESCRIPTION
Polymorphic associations cannot be saved when a new News is created.