### PR TITLE
Permissions: fixing redirect bug

### DIFF
--- a/app/controllers/admin/permissions_controller.rb
+++ b/app/controllers/admin/permissions_controller.rb
@@ -2,20 +2,18 @@
 class Admin::PermissionsController < Admin::BaseController
   load_permissions_and_authorize_resource
   load_and_authorize_resource :post
-  before_action :set_permissions
 
   def index
-    @posts = Post.title
+    @posts = Post.includes(:permissions).title
   end
 
   def show_post
     @permissions = Permission.subject
-    @post_permissions = @post.permissions.map(&:id)
   end
 
   def update_post
     if @post.set_permissions(permission_params)
-      redirect_to index_admin_permissions_path, notice: alert_update(Post)
+      redirect_to admin_permissions_path, notice: alert_update(Post)
     else
       render :show_post, status: 422
     end
@@ -25,9 +23,5 @@ class Admin::PermissionsController < Admin::BaseController
 
   def permission_params
     params.require(:post).permit(permission_ids: [])
-  end
-
-  def set_permissions
-    @permissions = Permission.all
   end
 end

--- a/app/views/admin/permissions/show_post.html.erb
+++ b/app/views/admin/permissions/show_post.html.erb
@@ -12,12 +12,13 @@
     <div class="panel-body">
       <table class="table table-bordered">
         <tbody>
-          <% @permissions.group_by(&:action).each do |action, permissions| %>
+          <% @permissions.group_by(&:subject_class).each do |subject_class, permissions| %>
             <tr>
-              <td><%= action %></td>
+              <td><%= subject_class %></td>
               <td>
                 <%= f.input(:permission_ids, collection: permissions,
-                                             label_method: :subject_class,
+                                             label: false,
+                                             label_method: :action,
                                              value_method: :id,
                                              as: :check_boxes,
                                              item_wrapper_class: 'inline') %>

--- a/config/locales/models/post.sv.yml
+++ b/config/locales/models/post.sv.yml
@@ -15,6 +15,7 @@ sv:
         board: Styrelsepost
         rec_limit: Rekommenderad gräns
         car_rent: Får hyra bil
+        permission_ids: Rättigheter
   post:
     added: "%{u} tilldelades %{p}"
     add_error: "Tilldelningen gick inte: %{errors}"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -117,20 +117,16 @@ ActiveRecord::Schema.define(version: 20160428130636) do
   add_index "contacts", ["slug"], name: "index_contacts_on_slug", using: :btree
 
   create_table "councils", force: :cascade do |t|
-    t.string   "title",             limit: 255
-    t.string   "url",               limit: 255
-    t.text     "description",       limit: 65535
+    t.string   "title",        limit: 255
+    t.string   "url",          limit: 255
+    t.text     "description",  limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "president_id",      limit: 4
-    t.datetime "logo_updated_at"
-    t.integer  "vicepresident_id",  limit: 4
-    t.integer  "contact_id",        limit: 4
-    t.integer  "logo_file_size",    limit: 4
-    t.string   "logo_content_type", limit: 255
-    t.string   "logo_file_name",    limit: 255
-    t.boolean  "public"
+    t.integer  "president_id", limit: 4
   end
+
+  add_index "councils", ["president_id"], name: "index_councils_on_president_id", using: :btree
+  add_index "councils", ["url"], name: "index_councils_on_url", using: :btree
 
   create_table "documents", force: :cascade do |t|
     t.string   "pdf_file_name",    limit: 255
@@ -400,7 +396,7 @@ ActiveRecord::Schema.define(version: 20160428130636) do
     t.string   "renter",      limit: 255,                 null: false
     t.string   "purpose",     limit: 255
     t.integer  "tool_id",     limit: 4,                   null: false
-    t.datetime "return_date",                             null: false
+    t.date     "return_date",                             null: false
     t.boolean  "returned",                default: false
     t.datetime "created_at",                              null: false
     t.datetime "updated_at",                              null: false

--- a/spec/controllers/admin/permissions_controller_spec.rb
+++ b/spec/controllers/admin/permissions_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Admin::PermissionsController, type: :controller do
+  allow_user_to(:manage, [Permission, PermissionPost, Post])
+
+  describe 'GET #index' do
+    it 'assigns a permission grid and categories' do
+      council = create(:council)
+      create(:post, title: 'Bpost', council: council)
+      the_post = create(:post, title: 'Apost', council: council)
+      create(:permission_post, post: the_post)
+
+      get(:index)
+      response.status.should eq(200)
+      assigns(:posts).map(&:title).should eq(['Apost', 'Bpost'])
+    end
+  end
+
+  describe 'GET #show_post' do
+    it 'assigns permissions as @permission, sorted by subject_class' do
+      the_post = create(:post)
+      create(:permission, name: 'Second', subject_class: 'tool')
+      permission = create(:permission, name: 'First', subject_class: 'cafe')
+      create(:permission_post, post: the_post, permission: permission)
+
+      get(:show_post, post_id: the_post.to_param)
+      assigns(:permissions).map(&:name).should eq(['First', 'Second'])
+    end
+  end
+
+  describe 'PATCH #update_post' do
+    it 'valid parameters' do
+      the_post = create(:post)
+      permission = create(:permission, name: 'Old')
+      create(:permission_post, post: the_post, permission: permission)
+
+      the_post.permissions.map(&:name).should eq(['Old'])
+
+      other_permission = create(:permission, name: 'New')
+
+      patch(:update_post, post_id: the_post.to_param,
+                          post: { permission_ids: [other_permission.to_param] })
+
+      response.should redirect_to(admin_permissions_path)
+      the_post.reload
+
+      the_post.permissions.map(&:name).should eq(['New'])
+    end
+  end
+end


### PR DESCRIPTION
After update_post it redirected to old path
Added spec to catch this bug
Change the view to show a posts permissions mapped by 
`:subject_class` instead of `:action`