### PR TITLE
I18n: enabling routing and globalize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'bullet'
   gem 'onesky-rails'
   gem 'quiet_assets'
   gem 'web-console'

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'fancybox2-rails'
 gem 'font-awesome-rails'
 gem 'fotoramajs'
 gem 'fullcalendar-rails'
+gem 'globalize', '~> 5.0.0'
+gem 'globalize-accessors'
 gem 'icalendar'
 gem 'jquery-rails'
 gem 'jquery-turbolinks'
@@ -31,6 +33,7 @@ gem 'pagedown-bootstrap-rails'
 gem 'prawn-rails'
 gem 'redcarpet'
 gem 'rollbar', '~>2.8.3'
+gem 'routing-filter', '~> 0.5.1'
 gem 'sass-rails'
 gem 'select2-rails'
 gem 'simple_form'
@@ -64,8 +67,9 @@ group :development, :test do
 end
 
 group :development do
-  gem 'web-console'
+  gem 'onesky-rails'
   gem 'quiet_assets'
+  gem 'web-console'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    domain_name (0.5.20160310)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.0)
     dotenv-rails (2.1.0)
       dotenv (= 2.1.0)
@@ -150,7 +152,14 @@ GEM
       momentjs-rails (>= 2.9.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    globalize (5.0.1)
+      activemodel (>= 4.2.0, < 4.3)
+      activerecord (>= 4.2.0, < 4.3)
+    globalize-accessors (0.1.5)
+      globalize (>= 3)
     highline (1.7.8)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     i18n-tasks (0.9.4)
       activesupport (>= 4.0.2)
@@ -190,7 +199,7 @@ GEM
     mimemagic (0.3.0)
     mini_magick (4.5.1)
     mini_portile2 (2.0.0)
-    minitest (5.8.4)
+    minitest (5.9.0)
     momentjs-rails (2.11.1)
       railties (>= 3.1)
     multi_json (1.12.0)
@@ -198,8 +207,14 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.0.2)
+    netrc (0.11.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    onesky-rails (1.2.0)
+      i18n (>= 0.5.0)
+      onesky-ruby (~> 1.0.0)
+    onesky-ruby (1.0.1)
+      rest-client (~> 1.8)
     orm_adapter (0.5.0)
     pagedown-bootstrap-rails (2.1.2)
       railties (> 3.1)
@@ -269,9 +284,16 @@ GEM
     ref (2.0.0)
     responders (2.1.2)
       railties (>= 4.2.0, < 5.1)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rollbar (2.8.3)
       multi_json
       rspec-support (~> 3.4.0)
+    routing-filter (0.5.1)
+      actionpack (~> 4.2)
+      activesupport (~> 4.2)
     rspec-core (3.4.4)
     rspec-example_steps (3.0.2)
       rspec-core (>= 3.0.0)
@@ -340,6 +362,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (3.1.1)
@@ -381,6 +406,8 @@ DEPENDENCIES
   font-awesome-rails
   fotoramajs
   fullcalendar-rails
+  globalize (~> 5.0.0)
+  globalize-accessors
   i18n-tasks
   icalendar
   jquery-rails
@@ -390,6 +417,7 @@ DEPENDENCIES
   mini_magick
   momentjs-rails
   mysql2 (~> 0.3.20)
+  onesky-rails
   pagedown-bootstrap-rails
   paperclip
   poltergeist
@@ -400,6 +428,7 @@ DEPENDENCIES
   rails (= 4.2.5.2)
   redcarpet
   rollbar (~> 2.8.3)
+  routing-filter (~> 0.5.1)
   rspec-example_steps
   rspec-rails
   sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.2)
+    bullet (5.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     byebug (8.2.2)
     cancancan (1.13.1)
     capistrano (3.4.0)
@@ -365,6 +368,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
+    uniform_notifier (1.10.0)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (3.1.1)
@@ -388,6 +392,7 @@ DEPENDENCIES
   better_errors
   bootstrap-datepicker-rails
   bootstrap-sass
+  bullet
   cancancan
   capistrano
   capistrano-passenger

--- a/app/assets/stylesheets/style/forms.scss
+++ b/app/assets/stylesheets/style/forms.scss
@@ -11,3 +11,14 @@
   margin-bottom: 15px;
 }
 
+.inline {
+  display: inline-block;
+
+  &.half {
+    width: 49.5%;
+  }
+
+  &.third {
+    width: 32.7%;
+  }
+}

--- a/app/assets/stylesheets/style/top.scss
+++ b/app/assets/stylesheets/style/top.scss
@@ -38,7 +38,7 @@
         text-transform: uppercase;
       }
 
-      li.devider {
+      .divider {
         border-right: solid 1px $dark-gray;
         font-size: 8px;
         margin: 0 9px 0 5px;

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -45,6 +45,7 @@ class Admin::ContactsController < Admin::BaseController
   private
 
   def contact_params
-    params.require(:contact).permit(:name, :email, :public, :text, :post_id, :slug)
+    params.require(:contact).permit(:name_sv, :name_en, :email, :public,
+                                    :text_sv, :name_en, :post_id, :slug)
   end
 end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -46,11 +46,12 @@ class Admin::EventsController < Admin::BaseController
   private
 
   def event_params
-    params.require(:event).permit(:title, :author, :description,
+    params.require(:event).permit(:title_sv, :title_en, :description_sv, :description_en,
+                                  :short_sv, :short_en, :author,
                                   :location, :starts_at, :ends_at,
                                   :all_day, :category, :image,
                                   :signup, :last_reg,
                                   :slots, :drink, :food, :cash,
-                                  :short, :council_id, :dot)
+                                  :council_id, :dot)
   end
 end

--- a/app/controllers/admin/gallery/albums_controller.rb
+++ b/app/controllers/admin/gallery/albums_controller.rb
@@ -48,8 +48,8 @@ class Admin::Gallery::AlbumsController < Admin::BaseController
   private
 
   def album_params
-    params.require(:album).permit(:title, :description, :location,
-                                  :public, :start_date, :end_date,
+    params.require(:album).permit(:title_sv, :title_en, :description_sv, :description_en,
+                                  :location, :public, :start_date, :end_date,
                                   :photographer_user, :photographer_name,
                                   image_upload: [])
   end

--- a/app/controllers/admin/menus_controller.rb
+++ b/app/controllers/admin/menus_controller.rb
@@ -48,6 +48,6 @@ class Admin::MenusController < Admin::BaseController
 
   def menu_params
     params.require(:menu).permit(:location, :index, :link,
-                                 :name, :visible, :turbolinks, :blank_p)
+                                 :name_sv, :name_en, :visible, :turbolinks, :blank_p)
   end
 end

--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -45,7 +45,7 @@ class Admin::NewsController < Admin::BaseController
   private
 
   def news_params
-    params.require(:news).permit(:title, :content, :image, :url,
-                                 :remove_image, category_ids: [])
+    params.require(:news).permit(:title_sv, :title_en, :content_sv, :content_en,
+                                 :image, :url, :remove_image, category_ids: [])
   end
 end

--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -28,7 +28,7 @@ class Admin::NewsController < Admin::BaseController
 
   def update
     @news = News.find(params[:id])
-    if @news.update(news_params)
+    if @news.update(news_params.merge!(updated_at: Time.zone.now))
       redirect_to edit_admin_news_path(@news), notice: alert_update(News)
     else
       render :edit, status: 422

--- a/app/controllers/admin/notices_controller.rb
+++ b/app/controllers/admin/notices_controller.rb
@@ -45,7 +45,8 @@ class Admin::NoticesController < Admin::BaseController
   private
 
   def notice_params
-    params.require(:notice).permit(:title, :description,
+    params.require(:notice).permit(:title_sv, :description_sv,
+                                   :title_en, :description_en,
                                    :public, :d_publish, :d_remove,
                                    :sort, :image, :remove_image)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,17 +108,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    locale = 'sv'
-    langs = %w{ sv en }
-
-    if params[:locale]
-      lang = params[:locale]
-      if langs.include? lang
-        locale = lang
-      end
-    end
-    I18n.locale = locale
-    redirect_to(:back) if params[:locale]
+    I18n.locale = params[:locale] || I18n.default_locale
+    Rails.application.routes.default_url_options[:locale] = I18n.locale
   end
 
   def referring_action

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -19,4 +19,14 @@ module MenuHelper
   def menu_dropdown_render(menus)
     content_tag(:ul, render(partial: 'menus/menu', collection: menus), class: 'dropdown-menu')
   end
+
+  def menu_locale_link(link, locale)
+    if link.present? && locale.present?
+      if !link.start_with?('http', 'https') && locale.to_s == 'en'
+        "/en#{link}"
+      else
+        link
+      end
+    end
+  end
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,9 @@
 # encoding: UTF-8
 class Album < ActiveRecord::Base
+  translates(:title, :description)
+  globalize_accessors(locales: [:en, :sv],
+                      attributes: [:title, :description])
+
   has_many :images, -> { order(:filename) }, dependent: :destroy
 
   attr_accessor(:image_upload, :photographer_user,

--- a/app/models/categorization.rb
+++ b/app/models/categorization.rb
@@ -1,6 +1,6 @@
 class Categorization < ActiveRecord::Base
   belongs_to :category
-  belongs_to :categorizable, polymorphic: true
+  belongs_to :categorizable, polymorphic: true, touch: true
 
   validates :category, :categorizable, presence: true
   validates :categorizable_id, uniqueness: { scope: [:category,

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,5 +1,9 @@
 # encoding: UTF-8
 class Contact < ActiveRecord::Base
+  translates(:name, :text)
+  globalize_accessors(locales: [:en, :sv],
+                      attributes: [:name, :text])
+
   belongs_to :post
   has_many :users, through: :post
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,10 @@
 # encoding: UTF-8
 class Event < ActiveRecord::Base
   TZID = 'Europe/Stockholm'.freeze
+  translates(:title, :description, :short)
+  globalize_accessors(locales: [:en, :sv],
+                      attributes: [:title, :description, :short])
+
   has_attached_file(:image,
                     styles: { original: '800x800>',
                               medium: '300x300>',

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,5 +1,9 @@
 # encoding: UTF-8
 class Menu < ActiveRecord::Base
+  translates(:name)
+  globalize_accessors(locales: [:en, :sv],
+                      attributes: [:name])
+
   GUILD = 'guild'.freeze
   MEMBER = 'members'.freeze
   COMPANY = 'companies'.freeze

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -1,5 +1,9 @@
 # encoding: UTF-8
 class News < ActiveRecord::Base
+  translates(:title, :content)
+  globalize_accessors(locales: [:en, :sv],
+                      attributes: [:title, :content])
+
   belongs_to :user
   has_many :categorizations, as: :categorizable
   has_many :categories, through: :categorizations

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,5 +1,8 @@
 # encoding: UTF-8
 class Notice < ActiveRecord::Base
+  translates(:title, :description)
+  globalize_accessors(locales: [:en, :sv], attributes: [:title, :description])
+
   belongs_to :user
   mount_uploader :image, AttachedImageUploader
 

--- a/app/view_objects/global_menus.rb
+++ b/app/view_objects/global_menus.rb
@@ -2,7 +2,7 @@ class GlobalMenus
   attr_accessor :guild_menus, :member_menus, :company_menus, :contact_menus
 
   def initialize
-    menus = Menu.index.group_by(&:location)
+    menus = Menu.includes(:translations).index.group_by(&:location)
     @guild_menus = menus[Menu::GUILD] || []
     @member_menus = menus[Menu::MEMBER] || []
     @company_menus = menus[Menu::COMPANY] || []

--- a/app/view_objects/start_page.rb
+++ b/app/view_objects/start_page.rb
@@ -2,8 +2,12 @@ class StartPage
   attr_accessor :news, :events, :notices
 
   def initialize(member: false)
-    @news = News.order(created_at: :desc).limit(5).includes(:user).includes(:categories) || []
-    @events = Event.stream || []
+    @news = News.includes(:translations).
+      includes(:user).
+      includes(:categories).
+      order(created_at: :desc).
+      limit(5) || []
+    @events = Event.includes(:translations).stream || []
     @notices = get_notices(member)
   end
 
@@ -11,9 +15,9 @@ class StartPage
 
   def get_notices(member)
     if member
-      Notice.published
+      Notice.includes(:translations).published
     else
-      Notice.publik.published
+      Notice.includes(:translations).publik.published
     end
   end
 end

--- a/app/views/admin/contacts/_form.html.erb
+++ b/app/views/admin/contacts/_form.html.erb
@@ -1,8 +1,10 @@
 <%= simple_form_for([:admin, contact]) do |f| %>
   <%= f.association(:post, collection: posts, input_html: { class: 'select2' },
                     hint: t('.name_or_post')) %>
-  <%= f.input :name %>
-  <%= f.input :text, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+  <%= f.input :name_sv, wrapper_html: {class: 'inline half'} %>
+  <%= f.input :name_en, wrapper_html: {class: 'inline half'} %>
+  <%= f.input :text_sv, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+  <%= f.input :text_en, as: :pagedown, input_html: { preview: true, rows: 10 } %>
   <%= f.input :email %>
   <%= f.input :public %>
   <%= f.input :slug, hint: t('.slug_description') %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -14,9 +14,12 @@
     </ul>
     <div class="tab-content">
       <div id="info" class="profile-edit tab-pane fade in <%= tab == :info ? 'active' : ''%>">
-        <%= f.input :title %>
-        <%= f.input :short %>
-        <%= f.input :description %>
+        <%= f.input :title_sv, wrapper_html: {class: 'inline half'} %>
+        <%= f.input :title_en, wrapper_html: {class: 'inline half'} %>
+        <%= f.input :short_sv, wrapper_html: {class: 'inline half'} %>
+        <%= f.input :short_en, wrapper_html: {class: 'inline half'} %>
+        <%= f.input :description_sv, as: :text %>
+        <%= f.input :description_en, as: :text %>
         <%= f.input :location %>
         <%= f.input :image, as: :file %>
         <%= f.association :council, collection: Council.titles %>

--- a/app/views/admin/gallery/albums/_form.html.erb
+++ b/app/views/admin/gallery/albums/_form.html.erb
@@ -1,7 +1,9 @@
 <%= simple_form_for([:admin,:gallery, @album]) do |f| %>
   <div class="form-inputs">
-    <%= f.input :title %>
-    <%= f.input :description %>
+    <%= f.input :title_sv, wrapper_html: {class: 'inline half'} %>
+    <%= f.input :title_en, wrapper_html: {class: 'inline half'} %>
+    <%= f.input :description_sv %>
+    <%= f.input :description_en %>
     <%= f.input :location %>
     <%= f.input :start_date, as: :datetime_picker %>
     <%= f.input :end_date, as: :datetime_picker %>

--- a/app/views/admin/menus/_form.html.erb
+++ b/app/views/admin/menus/_form.html.erb
@@ -6,7 +6,8 @@
                          input_html: { class: 'select2' },
                          include_blank: false %>
   <%= f.input :index %>
-  <%= f.input :name %>
+  <%= f.input :name_sv, wrapper_html: { class: 'inline half' } %>
+  <%= f.input :name_en, wrapper_html: { class: 'inline half' } %>
   <%= f.input :link %>
   <%= f.input :visible %>
   <%= f.input :turbolinks %>

--- a/app/views/admin/news/_form.html.erb
+++ b/app/views/admin/news/_form.html.erb
@@ -1,6 +1,8 @@
 <%= simple_form_for([:admin, news]) do |f| %>
-  <%= f.input :title %>
-  <%= f.input :content, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+  <%= f.input :title_sv %>
+  <%= f.input :content_sv, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+  <%= f.input :title_en %>
+  <%= f.input :content_en, as: :pagedown, input_html: { preview: true, rows: 10 } %>
   <%= f.input :url %>
 
 

--- a/app/views/admin/notices/_form.html.erb
+++ b/app/views/admin/notices/_form.html.erb
@@ -1,7 +1,9 @@
 <% if notice.present? %>
   <%= simple_form_for([:admin, notice]) do |f| %>
-    <%= f.input :title %>
-    <%= f.input :description, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+    <%= f.input :title_sv, wrapper_html: { class: 'inline half' } %>
+    <%= f.input :title_en, wrapper_html: { class: 'inline half' } %>
+    <%= f.input :description_sv, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+    <%= f.input :description_en, as: :pagedown, input_html: { preview: true, rows: 10 } %>
     <%= f.input :public %>
     <%= f.input :d_publish, as: :datetime_picker %>
     <%= f.input :d_remove, as: :datetime_picker %>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -4,7 +4,7 @@
   </h1>
 </div>
 <div class="col-md-12">
-  <% cache(@contacts) do %>
+  <% cache([@contacts, I18n.locale]) do %>
     <%= render @contacts %>
   <% end %>
 </div>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,6 +1,6 @@
 <div class="collapse navbar-collapse navbar-responsive-collapse">
   <ul class="nav navbar-nav navbar-right">
-    <% cache('main_menu', skip_digest: true) do %>
+    <% cache(['main_menu', I18n.locale]) do %>
       <% global_menus = GlobalMenus.new %>
       <%= menu_dropdown(menus: global_menus.guild_menus, title: t('model.menus.guild')) %>
       <%= menu_dropdown(menus: global_menus.member_menus, title: t('model.menus.members')) %>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,6 +1,6 @@
 <div class="collapse navbar-collapse navbar-responsive-collapse">
   <ul class="nav navbar-nav navbar-right">
-    <% cache(['main_menu', I18n.locale]) do %>
+    <% cache_unless(can_administrate?(:manage, Menu), ['main_menu', I18n.locale]) do %>
       <% global_menus = GlobalMenus.new %>
       <%= menu_dropdown(menus: global_menus.guild_menus, title: t('model.menus.guild')) %>
       <%= menu_dropdown(menus: global_menus.member_menus, title: t('model.menus.members')) %>

--- a/app/views/layouts/_topbar.html.erb
+++ b/app/views/layouts/_topbar.html.erb
@@ -3,11 +3,11 @@
     <ul class="loginbar pull-right">
       <li><%= link_to(fa_icon('calendar'), calendars_path,
                                            data: { no_turbolink: false }) %></li>
-      <li class="devider"></li>
+      <li class="divider"></li>
       <% if user_signed_in? %>
         <% if current_user.permissions.count > 0 %>
           <%= render 'layouts/admin_dropdown' %>
-          <li class="devider"></li>
+          <li class="divider"></li>
         <% end %>
 
         <li class="dropdown">
@@ -27,7 +27,7 @@
             <%= fa_icon('sign-in') %> <%= t('devise.sign_in') %>
           <% end %>
         </li>
-        <li class="devider"> </li>
+        <li class="divider"> </li>
         <li>
           <%= link_to(new_user_registration_path) do %>
             <%= fa_icon('plus') %> <%= t('devise.sign_up') %>

--- a/app/views/menus/_menu.html.erb
+++ b/app/views/menus/_menu.html.erb
@@ -1,21 +1,24 @@
 <% if menu.turbolinks && menu.blank_p %>
   <li class="menu blank">
-    <%= link_to(menu.link, target: :blank) do %>
+    <%= link_to(menu_locale_link(menu.link, I18n.locale), target: :blank) do %>
       <%= menu %>
       <%= fa_icon('external-link') %>
     <% end %>
   </li>
 <% elsif menu.turbolinks %>
-  <li><%= link_to(menu, menu.link) %></li>
+  <li><%= link_to(menu, menu_locale_link(menu.link, I18n.locale)) %></li>
 <% elsif menu.blank_p %>
   <li class="menu blank">
-    <%= link_to(menu.link, 'data-no-turbolink': true, target: :blank) do %>
+    <%= link_to(menu_locale_link(menu.link, I18n.locale),
+                'data-no-turbolink': true,
+                target: :blank) do %>
       <%= menu %>
       <%= fa_icon('external-link') %>
     <% end %>
   </li>
 <% else %>
   <li>
-    <%= link_to(menu, menu.link, 'data-no-turbolink': true) %>
+    <%= link_to(menu, menu_locale_link(menu.link, I18n.locale),
+                'data-no-turbolink': true) %>
   </li>
 <% end %>

--- a/app/views/news/_news.html.erb
+++ b/app/views/news/_news.html.erb
@@ -11,13 +11,15 @@
 
    <%= news_url(news) %>
 
-   <% if news.categories.count > 0 %>
-     <span class="categories">
-       <%= fa_icon('hashtag') %> 
-       <% news.categories.each do |cat| %>
-         <%= link_to(cat.title, news_index_path(category: cat.to_param)) %> <%= ' ' %>
-       <% end %>
-     </span>
+   <% cache([news.categories, I18n.locale]) do %>
+     <% if news.categories.any? %>
+       <span class="categories">
+         <%= fa_icon('hashtag') %>
+         <% news.categories.each do |cat| %>
+           <%= link_to(cat.title, news_index_path(category: cat.to_param)) %> <%= ' ' %>
+         <% end %>
+       </span>
+     <% end %>
    <% end %>
 
    <span class="date">

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -14,17 +14,25 @@
 <% end %>
 
 <div class="col-md-7 col-sm-12">
-  <%= render @start_page.notices %>
+  <% cache_unless(can_administrate?(:manage, Notice),
+                  [@start_page.notices, I18n.locale]) do %>
+    <%= render @start_page.notices %>
+  <% end %>
 </div>
 
 <div class="col-md-5 col-sm-12">
-  <%= render '/events/stream', events: @start_page.events %>
+  <% cache([@start_page.events, I18n.locale]) do %>
+    <%= render '/events/stream', events: @start_page.events %>
+  <% end %>
 
   <div class="headline headline-md">
     <h3><%= models_name(News) %></h3>
   </div>
-  <%= render @start_page.news %>
-  <%= link_to news_index_path do%>
-    <%= fa_icon('plus') %> <%= t('.more_news') %>
+  <% cache_unless(can_administrate?(:manage, News),
+                  [@start_page.news, I18n.locale]) do %>
+    <%= render @start_page.news %>
+    <%= link_to news_index_path do%>
+      <%= fa_icon('plus') %> <%= t('.more_news') %>
+    <% end %>
   <% end %>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,9 +48,19 @@ Fsek::Application.configure do
   config.action_controller.asset_host = PUBLIC_URL
   config.action_mailer.asset_host = PUBLIC_URL
 
-  config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = false
 
   # Don't log partials etc. in development.
   config.quiet_assets = true
   config.action_view.logger = nil
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = false
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+    Bullet.rollbar = true
+    Bullet.add_footer = true
+  end
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -9,6 +9,7 @@ base_locale: sv
 
 # Read and write translations.
 data:
+  router: pattern-router
   ## Translations are read from the file system. Supported format: YAML, JSON.
   ## Provide a custom adapter:
   # adapter: I18n::Tasks::Data::FileSystem
@@ -29,6 +30,7 @@ data:
     # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
     ## Catch-all default:
     # - config/locales/%{locale}.yml
+    - ['{:}.*', 'config/locales/**/\1.%{locale}.yml']
 
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: convervative_router

--- a/config/initializers/routing_filter.rb
+++ b/config/initializers/routing_filter.rb
@@ -1,0 +1,2 @@
+# Do not include default locale in generated URLs
+RoutingFilter::Locale.include_default_locale = false

--- a/config/locales/models/album.sv.yml
+++ b/config/locales/models/album.sv.yml
@@ -8,14 +8,19 @@ sv:
       album: Album
     attributes:
       album:
-        description: Beskrivning
         author: Upplagd av
-        location: Plats
-        public: Publik
-        start_date: Startdatum
+        created_at: Skapat
+        description: Beskrivning
+        description_en: Beskrivning - engelsk
+        description_sv: Beskrivning - svensk
         end_date: Slutdatum
         image_upload: Bilduppladdning
-        photographer_user: Fotograf
+        location: Plats
         photographer_name: Namn på fotograf (om ej medlem)
-        created_at: Skapat
+        photographer_user: Fotograf
+        public: Publik
+        start_date: Startdatum
+        title: Titel
+        title_en: Titel - engelsk
+        title_sv: Titel - svensk
         updated_at: Uppdaterat

--- a/config/locales/models/contact.sv.yml
+++ b/config/locales/models/contact.sv.yml
@@ -15,8 +15,12 @@ sv:
         email: E-post
         message: Meddelande
         name: Namn
+        name_sv: Namn - svenskt
+        name_en: Namn - engelskt
         post_id: Post
         public: Publik
         slug: Kortreferens
         text: Beskrivning
+        text_sv: Beskrivning - svensk
+        text_en: Beskrivning - engelsk
         updated_at: Uppdaterad

--- a/config/locales/models/event.sv.yml
+++ b/config/locales/models/event.sv.yml
@@ -11,6 +11,8 @@ sv:
         council: Utskott
         created_at: Skapat
         description: Beskrivning
+        description_sv: Beskrivning - svensk
+        description_en: Beskrivning - engelsk
         dot: Prickar
         drink: Alkohol
         ends_at: Slutar
@@ -20,8 +22,12 @@ sv:
         last_unreg: Sista avanmälningsdatum
         location: Plats
         short: Kort titel
+        short_sv: Kort titel - svensk
+        short_en: Kort titel - engelsk
         signup: Med anmälan
         slots: Antal platser
         starts_at: Startar
         title: Titel
+        title_sv: Titel - svensk
+        title_en: Titel - engelsk
         updated_at: Uppdaterat

--- a/config/locales/models/menu.sv.yml
+++ b/config/locales/models/menu.sv.yml
@@ -17,6 +17,8 @@ sv:
         index: Sorteringsindex
         link: Länk
         name: Namn
+        name_sv: Namn - svensk
+        name_en: Namn - engelsk
         visible: Synlig
         turbolinks: Turbolink
         blank_p: Öppna i ny flik

--- a/config/locales/models/news_model.sv.yml
+++ b/config/locales/models/news_model.sv.yml
@@ -8,9 +8,13 @@ sv:
       news:
         categories: Kategorier
         content: Text
+        content_sv: Text - svensk
+        content_en: Text - engelsk
         created_at: Skapad
         image: Bild
         remove_image: Ta bort bild
         title: Titel
+        title_sv: Titel - svensk
+        title_en: Titel - engelsk
         updated_at: Uppdaterad
         user: Upplagd av

--- a/config/locales/models/notice.sv.yml
+++ b/config/locales/models/notice.sv.yml
@@ -7,7 +7,11 @@ sv:
     attributes:
       notice:
         title: Titel
+        title_sv: Titel - svensk
+        title_en: Titel - engelsk
         description: Text
+        description_sv: Text - svensk
+        description_en: Text - engelsk
         public: Publik
         d_publish: Publiceringsdatum
         d_remove: Datum för borttagning

--- a/config/onesky.yml
+++ b/config/onesky.yml
@@ -1,0 +1,6 @@
+api_key: <%= ENV['ONESKY_API_KEY'] %>
+api_secret: <%= ENV['ONESKY_API_SECRET'] %>
+project_id: <%= ENV['ONESKY_PROJECT_ID'] %>
+
+upload:
+  is_keeping_all_strings: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Fsek::Application.routes.draw do
+  filter :locale, exclude: /^\/admin/
   # Resources on the page
   get('/vecktorn', to: redirect('http://fsektionen.us11.list-manage.com/subscribe?u=b115d5ab658a971e771610695&id=aeb6a02396'),
                    as: :vecktorn_signup, status: 301)

--- a/db/migrate/20160530171703_create_translation_for_news.rb
+++ b/db/migrate/20160530171703_create_translation_for_news.rb
@@ -1,0 +1,10 @@
+class CreateTranslationForNews < ActiveRecord::Migration
+  def up
+    News.create_translation_table!({ title: :string, content: :text },
+                                   { migrate_data: true })
+  end
+
+  def down
+    News.drop_translation_table! migrate_data: true
+  end
+end

--- a/db/migrate/20160530173909_create_translation_for_notices.rb
+++ b/db/migrate/20160530173909_create_translation_for_notices.rb
@@ -1,0 +1,10 @@
+class CreateTranslationForNotices < ActiveRecord::Migration
+  def up
+    Notice.create_translation_table!({ title: :string, description: :text },
+                                     { migrate_data: true })
+  end
+
+  def down
+    Notice.drop_translation_table! migrate_data: true
+  end
+end

--- a/db/migrate/20160530184105_create_translation_for_menus.rb
+++ b/db/migrate/20160530184105_create_translation_for_menus.rb
@@ -1,0 +1,10 @@
+class CreateTranslationForMenus < ActiveRecord::Migration
+  def up
+    Menu.create_translation_table!({ name: :string },
+                                   { migrate_data: true })
+  end
+
+  def down
+    Menu.drop_translation_table! migrate_data: true
+  end
+end

--- a/db/migrate/20160530184657_create_translation_for_contacts.rb
+++ b/db/migrate/20160530184657_create_translation_for_contacts.rb
@@ -1,0 +1,10 @@
+class CreateTranslationForContacts < ActiveRecord::Migration
+  def up
+    Contact.create_translation_table!({ name: :string, text: :text },
+                                      { migrate_data: true })
+  end
+
+  def down
+    Contact.drop_translation_table! migrate_data: true
+  end
+end

--- a/db/migrate/20160530185424_create_translation_for_albums.rb
+++ b/db/migrate/20160530185424_create_translation_for_albums.rb
@@ -1,0 +1,10 @@
+class CreateTranslationForAlbums < ActiveRecord::Migration
+  def up
+    Album.create_translation_table!({ title: :string, description: :text },
+                                    { migrate_data: true })
+  end
+
+  def down
+    Album.drop_translation_table! migrate_data: true
+  end
+end

--- a/db/migrate/20160530191925_create_translation_for_events.rb
+++ b/db/migrate/20160530191925_create_translation_for_events.rb
@@ -1,0 +1,10 @@
+class CreateTranslationForEvents < ActiveRecord::Migration
+  def up
+    Event.create_translation_table!({ title: :string, description: :text, short: :string },
+                                    { migrate_data: true })
+  end
+
+  def down
+    Event.drop_translation_table! migrate_data: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160428130636) do
+ActiveRecord::Schema.define(version: 20160530191925) do
+
+  create_table "album_translations", force: :cascade do |t|
+    t.integer  "album_id",    limit: 4,     null: false
+    t.string   "locale",      limit: 255,   null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.string   "title",       limit: 255
+    t.text     "description", limit: 65535
+  end
+
+  add_index "album_translations", ["album_id"], name: "index_album_translations_on_album_id", using: :btree
+  add_index "album_translations", ["locale"], name: "index_album_translations_on_locale", using: :btree
 
   create_table "albums", force: :cascade do |t|
     t.string   "title",       limit: 255
@@ -192,6 +204,19 @@ ActiveRecord::Schema.define(version: 20160428130636) do
     t.datetime "updated_at",               null: false
   end
 
+  create_table "event_translations", force: :cascade do |t|
+    t.integer  "event_id",    limit: 4,     null: false
+    t.string   "locale",      limit: 255,   null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.string   "title",       limit: 255
+    t.text     "description", limit: 65535
+    t.string   "short",       limit: 255
+  end
+
+  add_index "event_translations", ["event_id"], name: "index_event_translations_on_event_id", using: :btree
+  add_index "event_translations", ["locale"], name: "index_event_translations_on_locale", using: :btree
+
   create_table "events", force: :cascade do |t|
     t.string   "title",              limit: 255
     t.string   "author",             limit: 255
@@ -257,6 +282,17 @@ ActiveRecord::Schema.define(version: 20160428130636) do
   add_index "mail_aliases", ["target"], name: "index_mail_aliases_on_target", using: :btree
   add_index "mail_aliases", ["username", "domain", "target"], name: "index_mail_aliases_on_username_and_domain_and_target", unique: true, using: :btree
 
+  create_table "menu_translations", force: :cascade do |t|
+    t.integer  "menu_id",    limit: 4,   null: false
+    t.string   "locale",     limit: 255, null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.string   "name",       limit: 255
+  end
+
+  add_index "menu_translations", ["locale"], name: "index_menu_translations_on_locale", using: :btree
+  add_index "menu_translations", ["menu_id"], name: "index_menu_translations_on_menu_id", using: :btree
+
   create_table "menus", force: :cascade do |t|
     t.string   "location",   limit: 255
     t.integer  "index",      limit: 4
@@ -279,6 +315,18 @@ ActiveRecord::Schema.define(version: 20160428130636) do
     t.string   "image",      limit: 255
   end
 
+  create_table "news_translations", force: :cascade do |t|
+    t.integer  "news_id",    limit: 4,     null: false
+    t.string   "locale",     limit: 255,   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "title",      limit: 255
+    t.text     "content",    limit: 65535
+  end
+
+  add_index "news_translations", ["locale"], name: "index_news_translations_on_locale", using: :btree
+  add_index "news_translations", ["news_id"], name: "index_news_translations_on_news_id", using: :btree
+
   create_table "nominations", force: :cascade do |t|
     t.integer  "post_id",     limit: 4
     t.integer  "election_id", limit: 4
@@ -290,6 +338,18 @@ ActiveRecord::Schema.define(version: 20160428130636) do
     t.string   "phone",       limit: 255
     t.string   "stil_id",     limit: 255
   end
+
+  create_table "notice_translations", force: :cascade do |t|
+    t.integer  "notice_id",   limit: 4,     null: false
+    t.string   "locale",      limit: 255,   null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.string   "title",       limit: 255
+    t.text     "description", limit: 65535
+  end
+
+  add_index "notice_translations", ["locale"], name: "index_notice_translations_on_locale", using: :btree
+  add_index "notice_translations", ["notice_id"], name: "index_notice_translations_on_notice_id", using: :btree
 
   create_table "notices", force: :cascade do |t|
     t.string   "title",       limit: 255

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -102,6 +102,18 @@ ActiveRecord::Schema.define(version: 20160428130636) do
     t.datetime "updated_at"
   end
 
+  create_table "contact_translations", force: :cascade do |t|
+    t.integer  "contact_id", limit: 4,     null: false
+    t.string   "locale",     limit: 255,   null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.string   "name",       limit: 255
+    t.text     "text",       limit: 65535
+  end
+
+  add_index "contact_translations", ["contact_id"], name: "index_contact_translations_on_contact_id", using: :btree
+  add_index "contact_translations", ["locale"], name: "index_contact_translations_on_locale", using: :btree
+
   create_table "contacts", force: :cascade do |t|
     t.string   "name",       limit: 255
     t.string   "email",      limit: 255

--- a/spec/controllers/admin/contacts_controller_spec.rb
+++ b/spec/controllers/admin/contacts_controller_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe Admin::ContactsController, type: :controller do
 
   describe 'POST #create' do
     it 'valid params' do
-      attributes = { name: 'David',
+      attributes = { name_sv: 'David',
                      email: 'test@test.se',
                      public: 1,
-                     text: 'Jag kan svara på mejl' }
+                     text_sv: 'Jag kan svara på mejl' }
 
       lambda do
         post :create, contact: attributes
@@ -52,7 +52,7 @@ RSpec.describe Admin::ContactsController, type: :controller do
 
     it 'invalid params' do
       lambda do
-        post :create, contact: { name: nil }
+        post :create, contact: { name_sv: nil }
       end.should change(Contact, :count).by(0)
 
       response.should render_template(:new)
@@ -64,7 +64,7 @@ RSpec.describe Admin::ContactsController, type: :controller do
     it 'valid params' do
       contact = create(:contact, name: 'David')
 
-      post :update, id: contact.to_param, contact: { name: 'Titel' }
+      post :update, id: contact.to_param, contact: { name_sv: 'Titel' }
 
       contact.reload
       response.should redirect_to(edit_admin_contact_path(contact))
@@ -74,7 +74,7 @@ RSpec.describe Admin::ContactsController, type: :controller do
 
     it 'valid params' do
       contact = create(:contact, name: 'David')
-      post :update, id: contact.to_param, contact: { name: '' }
+      post :update, id: contact.to_param, contact: { name_sv: '' }
       contact.reload
 
       contact.name.should eq('David')

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Admin::EventsController, type: :controller do
   let(:user) { create(:user) }
-  let(:event) { create(:event) }
 
   allow_user_to(:manage, Event)
 
@@ -20,6 +19,8 @@ RSpec.describe Admin::EventsController, type: :controller do
 
   describe 'GET #edit' do
     it 'assigns a edit event as @event' do
+      event = create(:event)
+
       get(:edit, id: event.to_param)
       assigns(:event).should eq(event)
     end
@@ -27,16 +28,25 @@ RSpec.describe Admin::EventsController, type: :controller do
 
   describe 'GET #index' do
     it 'assigns events sorted as stat_date @events' do
+      create(:event, title: 'Second', starts_at: 5.days.ago)
+      create(:event, title: 'First', starts_at: 3.days.ago)
+      create(:event, title: 'Third', starts_at: 7.days.ago)
+
       get(:index)
-      assigns(:events).should match_array(Event.order(starts_at: :desc))
+      assigns(:events).map(&:title).should eq(['First', 'Second', 'Third'])
       response.status.should eq(200)
     end
   end
 
   describe 'POST #create' do
     it 'valid parameters' do
+      attributes = { title_sv: 'Välkomstgasque!',
+                     description_sv: 'Det blir mat och dryck, waow!',
+                     location: 'Kårhuset: Gasquesalen',
+                     starts_at: 5.days.from_now,
+                     ends_at: 7.days.from_now }
       lambda do
-        post :create, event: attributes_for(:event)
+        post :create, event: attributes
       end.should change(Event, :count).by(1)
 
       response.should redirect_to(edit_admin_event_path(Event.last))
@@ -44,7 +54,7 @@ RSpec.describe Admin::EventsController, type: :controller do
 
     it 'invalid parameters' do
       lambda do
-        post :create, event: { title: 'Not enough' }
+        post :create, event: { title_sv: 'Not enough' }
       end.should change(Event, :count).by(0)
 
       response.should render_template(:new)
@@ -53,14 +63,16 @@ RSpec.describe Admin::EventsController, type: :controller do
 
   describe 'PATCH #update' do
     it 'valid parameters' do
-      patch :update, id: event.to_param, event: { title: 'Hej' }
+      event = create(:event, title: 'Välkomstgasque')
+      patch :update, id: event.to_param, event: { title_sv: 'Nollegasque' }
       event.reload
-      event.title.should eq('Hej')
+      event.title.should eq('Nollegasque')
       response.should redirect_to(edit_admin_event_path(event))
     end
 
     it 'valid parameters' do
-      patch :update, id: event.to_param, event: { title: '' }
+      event = create(:event, title: 'Välkomstgasque')
+      patch :update, id: event.to_param, event: { title_sv: '' }
       response.should render_template(:edit)
     end
   end

--- a/spec/controllers/admin/gallery/albums_controller_spec.rb
+++ b/spec/controllers/admin/gallery/albums_controller_spec.rb
@@ -2,20 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Admin::Gallery::AlbumsController, type: :controller do
   let(:user) { create(:admin) }
-  let(:album) { create(:album) }
-  let(:new_album) { build(:album) }
 
-  # Should be Album, Image and :gallery
-  # Cannot get it to work /dwessman
   allow_user_to(:manage, :all)
 
   before(:each) do
-    album.reload
     allow(controller).to receive(:current_user) { user }
   end
 
   describe 'GET #show' do
     it 'assigns the requested album as @album' do
+      album = create(:album)
+
       get(:show, id: album.to_param)
       assigns(:album).should eq(album)
     end
@@ -31,15 +28,25 @@ RSpec.describe Admin::Gallery::AlbumsController, type: :controller do
 
   describe 'GET #index' do
     it 'assigns albums sorted as @albums' do
+      create(:album, title: 'Second', start_date: 5.days.ago)
+      create(:album, title: 'First', start_date: 4.days.ago)
+      create(:album, title: 'Third', start_date: 6.days.ago)
+
       get(:index)
-      assigns(:albums).should match_array(Album.all.order(start_date: :desc))
+      assigns(:albums).map(&:title).should eq(['First', 'Second', 'Third'])
     end
   end
 
   describe 'POST #create' do
     it 'posts new album' do
+      attributes = { title_sv: 'Välkomstgasque',
+                     description_sv: 'Detta är en välkomstgasque!',
+                     location: 'Kårhuset: Gasquesalen',
+                     start_date: 2.days.ago,
+                     end_date: 2.days.ago + 5.hours }
+
       lambda do
-        post :create, album: attributes_for(:album)
+        post :create, album: attributes
       end.should change(Album, :count).by(1)
 
       response.should redirect_to(admin_gallery_album_path(Album.last))
@@ -48,12 +55,14 @@ RSpec.describe Admin::Gallery::AlbumsController, type: :controller do
 
   describe 'PATCH #update' do
     it 'update album' do
+      album = create(:album, title: 'Välkomstgasque')
       patch(:update, id: album.to_param, \
-            album: { title: 'Hej',
-                     image_upload: [Rack::Test::UploadedFile.new(File.open('app/assets/images/hilbert.jpg'))],
-                     photographer_user: user.id, photographer_name: user.firstname })
+                     album: { title_sv: 'Nollegasque',
+                              image_upload: [Rack::Test::UploadedFile.new(File.open('app/assets/images/hilbert.jpg'))],
+                              photographer_user: user.id, photographer_name: user.firstname })
+
       album.reload
-      album.title.should eq('Hej')
+      album.title.should eq('Nollegasque')
       response.should redirect_to(admin_gallery_album_path(album))
       album.images.count.should eq(1)
       album.images.last.photographer.should eq(user)

--- a/spec/controllers/admin/menus_controller_spec.rb
+++ b/spec/controllers/admin/menus_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Admin::MenusController, type: :controller do
 
   describe 'POST #create' do
     it 'valid parameters' do
-      attributes = { name: 'Bildgalleri',
+      attributes = { name_sv: 'Bildgalleri',
                      location: 'guild',
                      index: 1337,
                      link: '/galleri',
@@ -55,7 +55,7 @@ RSpec.describe Admin::MenusController, type: :controller do
 
     it 'invalid parameters' do
       lambda do
-        post :create, menu: { name: '' }
+        post :create, menu: { name_sv: '' }
       end.should change(Menu, :count).by(0)
 
       response.status.should eq(422)
@@ -67,7 +67,7 @@ RSpec.describe Admin::MenusController, type: :controller do
     it 'valid parameters' do
       menu = create(:menu, name: 'Aftonbladet')
 
-      patch :update, id: menu.to_param, menu: { name: 'Bildgalleri' }
+      patch :update, id: menu.to_param, menu: { name_sv: 'Bildgalleri' }
       menu.reload
 
       response.should redirect_to(edit_admin_menu_path(menu))
@@ -77,7 +77,7 @@ RSpec.describe Admin::MenusController, type: :controller do
     it 'invalid parameters' do
       menu = create(:menu, name: 'Bildgalleri')
 
-      patch :update, id: menu.to_param, menu: { name: '' }
+      patch :update, id: menu.to_param, menu: { name_sv: '' }
       menu.reload
 
       menu.name.should eq('Bildgalleri')

--- a/spec/controllers/admin/news_controller_spec.rb
+++ b/spec/controllers/admin/news_controller_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe Admin::NewsController, type: :controller do
   end
 
   describe 'GET #index' do
-    include Wice::Controller
     it 'assigns news sorted as @news' do
+      create(:news)
+      create(:news)
+
       get(:index)
       response.status.should eq(200)
     end
@@ -28,8 +30,11 @@ RSpec.describe Admin::NewsController, type: :controller do
 
   describe 'POST #create' do
     it 'posts new news' do
+      attributes = { title_sv: 'Sektionsmöte wohoo!',
+                     content_sv: 'Detta är en text om sektionsmötet',
+                     url: 'https://rostsystem.se' }
       lambda do
-        post :create, news: attributes_for(:news)
+        post :create, news: attributes
       end.should change(News, :count).by(1)
 
       response.should redirect_to(edit_admin_news_path(News.last))
@@ -38,9 +43,11 @@ RSpec.describe Admin::NewsController, type: :controller do
 
   describe 'PATCH #update' do
     it 'update news' do
-      patch :update, id: news.to_param, news: { title: 'Hej' }
+      news = create(:news, title: 'Vårterminsmöte')
+      patch :update, id: news.to_param, news: { title_sv: 'Höstterminsmöte' }
+
       news.reload
-      news.title.should eq('Hej')
+      news.title.should eq('Höstterminsmöte')
       response.should redirect_to(edit_admin_news_path(news))
     end
   end

--- a/spec/controllers/admin/notices_controller_spec.rb
+++ b/spec/controllers/admin/notices_controller_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Admin::NoticesController, type: :controller do
 
   describe 'POST #create' do
     it 'valid parameters' do
-      attributes = { title: 'Spindelmän regerar',
-                     description: 'Blaha blaha *strong*',
+      attributes = { title_sv: 'Spindelmän regerar',
+                     description_sv: 'Blaha blaha *strong*',
                      public: true,
                      d_publish: 2.days.ago,
                      sort: 10 }
@@ -57,7 +57,7 @@ RSpec.describe Admin::NoticesController, type: :controller do
 
     it 'invalid parameters' do
       lambda do
-        post :create, notice: { title: '' }
+        post :create, notice: { title_sv: '' }
       end.should change(Notice, :count).by(0)
 
       response.status.should eq(422)
@@ -70,7 +70,7 @@ RSpec.describe Admin::NoticesController, type: :controller do
       notice = create(:notice, title: 'A Bad Title')
       notice.user.should_not eq(user)
 
-      patch :update, id: notice.to_param, notice: { title: 'A Good Title' }
+      patch :update, id: notice.to_param, notice: { title_sv: 'A Good Title' }
       notice.reload
 
       response.should redirect_to(edit_admin_notice_path(notice))
@@ -82,7 +82,7 @@ RSpec.describe Admin::NoticesController, type: :controller do
     it 'invalid parameters' do
       notice = create(:notice, title: 'A Good Title')
 
-      patch :update, id: notice.to_param, notice: { title: '' }
+      patch :update, id: notice.to_param, notice: { title_sv: '' }
       notice.reload
 
       notice.title.should eq('A Good Title')


### PR DESCRIPTION
Enabling `/sv` (also as default) and `/en/` routing.
Enabling Globalize (object translations) for:
- Event
- News
- Notice
- Menu
- Album
- Contact