### PR TITLE
Changes robots.txt

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -15,6 +15,10 @@ class StaticPagesController < ApplicationController
   def company_about
   end
 
+  def robots
+    render :robots, content_type: 'text/plain'
+  end
+
   def index
     member = current_user.present? && current_user.member?
     @start_page = StartPage.new(member: member)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,7 +24,9 @@ class Ability
     # But cannot view any albums
     can :index, :gallery
     can [:index, :matrix, :modal], :nollning
-    can [:index, :about, :cookies_information, :company_about, :company_offer], :static_pages
+    can [:index, :about,
+         :cookies_information, :company_about,
+         :company_offer, :robots], :static_pages
 
     # Abilities all signed in users get
     if user.id.present?

--- a/app/views/static_pages/robots.text.erb
+++ b/app/views/static_pages/robots.text.erb
@@ -1,0 +1,9 @@
+<% if Rails.env.production? %>
+  User-Agent: *
+  Allow: /
+  Disallow: /admin
+  Sitemap: https://fsektionen.se/sitemaps/sitemap.xml.gz
+<% else %>
+  User-Agent: *
+  Disallow: /
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Fsek::Application.routes.draw do
   get :about, controller: :static_pages, path: :om
   get 'foretag/om', controller: :static_pages, action: :company_about, as: :company_about
   get 'foretag/vi-erbjuder', controller: :static_pages, action: :company_offer, as: :company_offer
+  get 'robots.:format', controller: :static_pages, action: :robots, as: :robots
 
   # User-related routes
   devise_for :users, skip: [:sessions, :registrations]

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,0 @@
-# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
-Sitemap: https://fsektionen.se/sitemaps/sitemap.xml.gz
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Ability do
                           :cookies_information,
                           :company_about,
                           :company_offer,
-                          :about],
+                          :about, :robots],
                     no: [] }
   }
 


### PR DESCRIPTION
Because search engines do not like similar content, our production app should be
the only part searched by robots.

Tells Search Engine not to follow our staging app.