### PR TITLE
RSpec locale: set to :sv after(:each)

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,7 @@ RSpec.configure do |config|
 
   config.after(:each) do
     Warden.test_reset!
+    I18n.locale = :sv
   end
 
   config.extend ControllerMacros, type: :controller


### PR DESCRIPTION
There have been some previous failing tests, and based on
http://stackoverflow.com/questions/36040661/specs-of-my-rails-app-fail-randomly-because-of-wrong-default-locale
this might be a solution.
rspec --bisect did not return an error, I guess it would need a specific seed.