### PR TITLE
Contact: change name of from

### DIFF
--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -1,5 +1,4 @@
 class ContactMailer < ApplicationMailer
-  default from: 'Kontaktformulär <dirac@fsektionen.se>'
   default subject: I18n.t('contact_mailer.subject')
 
   def contact_email(contact)
@@ -8,8 +7,9 @@ class ContactMailer < ApplicationMailer
 
       recipient = "#{contact.name} <#{contact.email}>"
       sender = "#{contact.message.name} <#{contact.message.email}>"
+      from = I18n.t('contact_mailer.from', sender: contact.message.name, email: 'dirac@fsektionen.se')
 
-      mail(to: recipient, cc: sender, reply_to: sender)
+      mail(from: from, to: recipient, cc: sender, reply_to: sender)
     end
   end
 end

--- a/config/locales/views/contacts/contact_mailer.sv.yml
+++ b/config/locales/views/contacts/contact_mailer.sv.yml
@@ -1,6 +1,7 @@
 sv:
   contact_mailer:
     subject: "F-sektionen: kontaktformulär"
+    from: "Kontaktformulär - %{sender} <%{email}>"
 
     contact_email:
       message_sent_via: Meddelande skickat via Fsektionen.se


### PR DESCRIPTION
When only having _Contact form <dirac@fsektionen.se>_ the messages will sort as
the same sender in Google Inbox (perhaps also in other)
Adding the senders name will make them personal.