### PR TITLE
Redirect: only redirect to html-request on login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_devise_parameters, if: :devise_controller?
-  before_action :store_current_location, unless: :devise_controller?
+  before_action :store_current_location, unless: 'devise_controller? || !request.format.html?'
   before_action :set_locale
   before_action :prepare_meta_tags, if: 'request.get?'
 


### PR DESCRIPTION
If you went to /hilbertcafe the last GET-request which was stored was the
calendar fetching a json-feed. And if you then signed in to the page you were
redirected to the json-feed instead of /hilbertcafe.

Now the filter checks that the request was html.