### PR TITLE
Foreman: makes it easier to start workers and web

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ end
 
 group :development do
   gem 'bullet'
+  gem 'foreman'
   gem 'onesky-rails'
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,8 @@ GEM
       railties (>= 3.1.0, < 5.0)
     font-awesome-rails (4.6.3.0)
       railties (>= 3.2, < 5.1)
+    foreman (0.82.0)
+      thor (~> 0.19.1)
     fotoramajs (4.6.4)
       sprockets (>= 2)
     fullcalendar-rails (2.6.1.0)
@@ -415,6 +417,7 @@ DEPENDENCIES
   factory_girl_rails
   fancybox2-rails
   font-awesome-rails
+  foreman
   fotoramajs
   fullcalendar-rails
   globalize (~> 5.0.0)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+web: bundle exec rails s
+redis: redis-server
+worker: bundle exec sidekiq


### PR DESCRIPTION
When using the new background workers locally in development you need to start three processes.

This is way easier to do with a `Procfile` and something called [`Foreman`](https://github.com/ddollar/foreman).

With this, Redis, and Sidekiq setup you can just call: `foreman start` and it keeps all three servers running for you.