### PR TITLE
Candidate: update email link to index view

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -19,10 +19,6 @@ class Candidate < ActiveRecord::Base
     end
   end
 
-  def p_url
-    Rails.application.routes.url_helpers.candidate_url(id, host: PUBLIC_URL)
-  end
-
   def editable_until
     if election.present? && post.present?
       election.post_closing(post)

--- a/app/views/election_mailer/candidate_email.html.erb
+++ b/app/views/election_mailer/candidate_email.html.erb
@@ -20,7 +20,7 @@
                     date: l(@candidate.election.post_closing(@candidate.post)))) %>
 <br>
 
-<%= link_to(t('.show_your_candidacy'), @candidate.p_url, class: 'btn') %>
+<%= link_to(t('.show_your_candidacies'), candidates_url(host: PUBLIC_URL), class: 'btn') %>
 <br>
 <br>
 

--- a/config/locales/views/elections/election_mailer.sv.yml
+++ b/config/locales/views/elections/election_mailer.sv.yml
@@ -7,7 +7,7 @@ sv:
       sincerely: Mvh, Valberedningen
       subject_candidated: Du har kandiderat till en post på Fsektionen.se
       you_have_candidated: Du har kandiderat till sektionsposten
-      show_your_candidacy: Visa kandidatur
+      show_your_candidacies: Visa kandidaturer
 
     nominate_email:
       accept_before_closing: "Tänk på att du måste tacka ja, kandidera, innan valet för posten stänger, %{date}."


### PR DESCRIPTION
The emails linked to candidate/show which no longer exists.
Now it will not.