### PR TITLE
Sidekiq: restore worker

### DIFF
--- a/app/worker/image_worker.rb
+++ b/app/worker/image_worker.rb
@@ -2,7 +2,6 @@ class ImageWorker < ActiveJob::Base
   include ::CarrierWave::Workers::StoreAssetMixin
 
   def when_not_ready
-    ## Stop this insanity!
-    #retry_job
+    retry_job
   end
 end


### PR DESCRIPTION
A process restarted infinitely because the image was removed.
Restore to normal function, seems to lack a way to do it better right now.
https://github.com/lardawge/carrierwave_backgrounder/issues/244