### PR TITLE
Image worker: adds error raising on file not found

### DIFF
--- a/app/worker/image_worker.rb
+++ b/app/worker/image_worker.rb
@@ -4,4 +4,8 @@ class ImageWorker < ActiveJob::Base
   def when_not_ready
     retry_job
   end
+
+  def when_not_found
+    raise ActiveRecord::RecordNotFound
+  end
 end


### PR DESCRIPTION
Based on
https://github.com/lardawge/carrierwave_backgrounder/issues/244#issuecomment-260345869
this will check if a record is not found as well as not ready.