### PR TITLE
Turbolinks: remove javascript async loading

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': true %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': true, async: Rails.env.production? %>
+    <%= stylesheet_link_tag 'application',
+                            media: 'all',
+                            'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application',
+                               'data-turbolinks-track': 'reload' %>
     <%= csrf_meta_tags %>
     <%= render '/layouts/favicon' %>
   </head>


### PR DESCRIPTION
Due to cold-loading issues with Turbolinks 5, the async is removed for now.
Fixes issue #591.