### PR TITLE
Election translations

### DIFF
--- a/app/assets/javascripts/countdown.js
+++ b/app/assets/javascripts/countdown.js
@@ -1,6 +1,6 @@
 function ready() {
   $('.timer').countdown($('.timer').data('time'), function(event) {
-    $(this).html(event.strftime('%D dagar %H:%M:%S'));
+    $(this).html(event.strftime($('.timer').data('format')));
   });
 };
 

--- a/app/assets/stylesheets/style/forms.scss
+++ b/app/assets/stylesheets/style/forms.scss
@@ -13,6 +13,7 @@
 
 .inline {
   display: inline-block;
+  vertical-align: top;
 
   &.half {
     width: 49.5%;

--- a/app/controllers/admin/elections_controller.rb
+++ b/app/controllers/admin/elections_controller.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 class Admin::ElectionsController < Admin::BaseController
   load_permissions_and_authorize_resource find_by: :url
 
@@ -8,7 +7,7 @@ class Admin::ElectionsController < Admin::BaseController
 
   def show
     @election = Election.find_by_url!(params[:id])
-    @post_grid = initialize_grid(@election.posts, include: :council)
+    @post_grid = initialize_grid(@election.posts, include: [:translations, :council])
   end
 
   def edit
@@ -16,7 +15,7 @@ class Admin::ElectionsController < Admin::BaseController
   end
 
   def index
-    @grid = initialize_grid(Election, order: :open)
+    @grid = initialize_grid(Election, include: :translations, order: :open)
   end
 
   def create
@@ -59,7 +58,8 @@ class Admin::ElectionsController < Admin::BaseController
   private
 
   def election_params
-    params.require(:election).permit(:title, :description, :open, :close_general, :close_all,
+    params.require(:election).permit(:title_sv, :title_en, :description_sv, :description_en,
+                                     :open, :close_general, :close_all,
                                      :url, :visible, :mail_link, :board_mail_link,
                                      :nominate_mail, :candidate_mail, :semester,
                                      :candidate_mail_star, extra_post_ids: [])

--- a/app/controllers/elections_controller.rb
+++ b/app/controllers/elections_controller.rb
@@ -9,14 +9,18 @@ class ElectionsController < ApplicationController
       @election_view.grid = initialize_grid(election.current_posts,
                                             name: :main,
                                             per_page: 50,
-                                            include: [:translations, council: :translations])
+                                            include: [:translations, council: :translations],
+                                            custom_order: { 'posts.id' => 'post_translations.title' },
+                                            order: 'id')
       @count = election.post_count
 
       if election.after_posts.any?
         @election_view.rest_grid = initialize_grid(election.after_posts,
                                                    name: :rest,
                                                    per_page: 50,
-                                                   include: [:translations, council: :translations])
+                                                   include: [:translations, council: :translations],
+                                                   custom_order: { 'posts.id' => 'post_translations.title' },
+                                                   order: 'id')
       end
     else
       render '/elections/no_election'

--- a/app/models/election.rb
+++ b/app/models/election.rb
@@ -1,9 +1,11 @@
-# encoding: UTF-8
 class Election < ActiveRecord::Base
   has_many :nominations, dependent: :destroy
   has_many :candidates, dependent: :destroy, inverse_of: :election
   has_many :election_posts, dependent: :destroy
   has_many :extra_posts, class_name: Post, through: :election_posts, source: :post
+
+  translates(:title, :description, fallbacks_for_empty_translations: true)
+  globalize_accessors(locales: [:en, :sv], attributes: [:title, :description])
 
   validates :url, uniqueness: true,
                   presence: true,
@@ -18,11 +20,11 @@ class Election < ActiveRecord::Base
   def posts
     case semester
     when Post::AUTUMN
-      Post.autumn.by_title
+      Post.autumn
     when Post::SPRING
-      Post.spring.by_title
+      Post.spring
     when Post::OTHER
-      extra_posts.by_title
+      extra_posts
     else
       Post.none
     end

--- a/app/views/admin/elections/_form.html.erb
+++ b/app/views/admin/elections/_form.html.erb
@@ -1,17 +1,19 @@
 <%= simple_form_for([:admin, election]) do |f| %>
-  <%= f.input :title, wrapper_html: {class: 'inline third'} %>
+  <%= f.input :title_sv, wrapper_html: {class: 'inline half'} %>
+  <%= f.input :title_en, wrapper_html: {class: 'inline half'} %>
   <%= f.input :semester, collection: [[t("model.post.semester.#{Post::AUTUMN}"), Post::AUTUMN],
                                       [t("model.post.semester.#{Post::SPRING}"), Post::SPRING],
                                       [t("model.post.semester.#{Post::OTHER}"), Post::OTHER]],
                          include_blank: false,
                          input_html: {class: 'select2'},
-                         wrapper_html: {class: 'inline third'} %>
-  <%= f.input :url, wrapper_html: {class: 'inline third'} %>
+                         wrapper_html: {class: 'inline half'} %>
+  <%= f.input :url, wrapper_html: {class: 'inline half'} %>
   <%= simple_format(t('.semester_hint_for_other')) %>
   <%= f.input :open, as: :datetime_picker %>
   <%= f.input :close_general, as: :datetime_picker %>
   <%= f.input :close_all, as: :datetime_picker %>
-  <%= f.input :description, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+  <%= f.input :description_sv, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+  <%= f.input :description_en, as: :pagedown, input_html: { preview: true, rows: 10 } %>
   <%= f.input :board_mail_link %>
   <%= f.input :mail_link %>
   <%= f.input :visible %>

--- a/app/views/admin/elections/index.html.erb
+++ b/app/views/admin/elections/index.html.erb
@@ -9,7 +9,9 @@
 
 <div class="col-md-10 col-sm-12">
   <%= grid(@grid, hide_submit_button: true, hide_reset_button: true) do |g|
-    g.column(name: Election.human_attribute_name(:title), attribute: 'title', filter: false)
+    g.column(name: Election.human_attribute_name(:title), filter: false) do |election|
+      election.title
+    end
     g.column(name: Election.human_attribute_name(:url), attribute: 'url', filter: false)
     g.column(name: Election.human_attribute_name(:open), attribute: 'open',
              filter: false) do |election|

--- a/app/views/elections/_countdown.html.erb
+++ b/app/views/elections/_countdown.html.erb
@@ -1,8 +1,9 @@
 <% if election_view.present? && election_view.election.countdown.present? %>
   <div class="countdown row">
     <h3><%= election_view.countdown_text %></h3>
-    <div class="timer" data-time="<%=l(election_view.election.countdown,
-                                       format: '%Y/%m/%d %H:%M:%S %z')%>">
+    <div class="timer" data-format="<%= t('.date_format') %>"
+                       data-time="<%=l(election_view.election.countdown,
+                                  format: '%Y/%m/%d %H:%M:%S %z')%>">
     </div>
   </div>
 <% end %>

--- a/app/views/elections/_posttab.html.erb
+++ b/app/views/elections/_posttab.html.erb
@@ -10,7 +10,7 @@
       end
     end
 
-    g.column(name: Post.human_attribute_name(:title)) do |post|
+    g.column(name: Post.human_attribute_name(:title), attribute: 'id', filter: false) do |post|
       election_post_link(post)
     end
 

--- a/config/locales/defaults/date.sv.yml
+++ b/config/locales/defaults/date.sv.yml
@@ -1,7 +1,7 @@
 sv:
   date:
     formats:
-      default: '%e %b %Y'
+      default: '%-e %b %Y'
       long: '%e %B %Y'
       short: '%e %b'
       day_month: '%e %b'

--- a/config/locales/defaults/time.sv.yml
+++ b/config/locales/defaults/time.sv.yml
@@ -2,7 +2,7 @@ sv:
   time:
     am: ''
     formats:
-      default: '%H:%M, %e %b %Y'
+      default: '%H:%M, %-e %b %Y'
       default_without: '%H, %e %b %Y'
       default_dot: '%H(.), %e %b %Y'
       default_ddot: '%H(..), %e %b %Y'

--- a/config/locales/models/election.sv.yml
+++ b/config/locales/models/election.sv.yml
@@ -11,14 +11,16 @@ sv:
         candidate_mail_star: Text till kandideringsmail för stjärnpost
         close_all: Stänger - allt
         current_election: Aktuellt val
-        description: Beskrivning
+        description_sv: Beskrivning - svensk
+        description_en: Beskrivning - engelsk
         extra_posts: Poster vid ej ordinarie möte
         mail_link: Länk i kandideringsmail
         nominate_mail: Text till nomineringsmail
         semester: Termin
         open: Öppnar
         close_general: Stänger - inför sektionsmöte
-        title: Titel
+        title_sv: Titel - svensk
+        title_en: Titel - engelsk
         updated_at: Uppdaterad
         url: Url
         visible: Synlig

--- a/config/locales/onesky_en/date.en.yml
+++ b/config/locales/onesky_en/date.en.yml
@@ -7,7 +7,7 @@
 en:
   date:
     formats:
-      default: "%e %b %Y"
+      default: "%-e %b %Y"
       long: "%e %B %Y"
       short: "%e %b"
       day_month: "%e %b"

--- a/config/locales/onesky_en/elections.en.yml
+++ b/config/locales/onesky_en/elections.en.yml
@@ -8,10 +8,11 @@ en:
   elections:
     countdown:
       days: dagar
+      date_format: "%D days %H:%M:%S"
     index:
       description: "Val på F-sektionen är då funktionärer och förtroendevalda blir valda. Se vilka poster som finns och sök idag."
       edit_election: "Edit election"
-      green_posts: "Green rows means the position is chosen by the council of education"
+      green_posts: "Positions highlighted in green are chosen by the Council of Education."
       keywords:
         - engagera
         - sektionsval
@@ -19,9 +20,10 @@ en:
         - terminsmöte
         - val
         - post
-      orange_posts: "Orange boxes mean the postition is part of the board"
+      highlights: What do the colors and markings mean?
+      orange_posts: "Positions highlighted in orange are members of the Board or the Council of Executives."
       star_posts: "Positions with * have no set limit."
-      x_posts: "Posts with a number marked (x) denote a set maximum number."
+      x_posts: "denotes a set maximum number."
     no_election:
       no_information: "There is currently no information available regarding the election"
       to_root: "Tillbaka till start"

--- a/config/locales/onesky_en/index_static_pages.en.yml
+++ b/config/locales/onesky_en/index_static_pages.en.yml
@@ -17,6 +17,8 @@ en:
       second_paragraph: "The guild has its spaces in Mattehuset where you can find common rooms, microwave-ovens, and the guilds own Hilbert Café - where you can buy coffee and great baguettes. The F-guild have a councils in charge of different parts of guilds function. Each council is headed by a chairman who is also a part of the guilds Board. The Board are in charge of the central function of the guild."
       third_paragraph: "As a member of the guild you can choose to be active and committed or take part at some events. We hope that you will enjoy your time in the F-guild. If you have any questions you can always get in touch with someone from the board, via the Contact tab on the website or in Styrelserummet in the far left of the Hilbert corridor (behind Hilbert Café)!"
       title: "About us"
+    countdown:
+      election_link: Read more about the election here
     index:
       welcome: "Welcome to the F-guild"
       days: days

--- a/config/locales/onesky_en/time.en.yml
+++ b/config/locales/onesky_en/time.en.yml
@@ -8,7 +8,7 @@ en:
   time:
     am: am
     formats:
-      default: "%H:%M, %e %b %Y"
+      default: "%H:%M, %-e %b %Y"
       default_without: "%H, %e %b %Y"
       default_dot: "%H(.), %e %b %Y"
       default_ddot: "%H(..), %e %b %Y"

--- a/config/locales/views/elections/elections.sv.yml
+++ b/config/locales/views/elections/elections.sv.yml
@@ -2,6 +2,7 @@ sv:
   elections:
     countdown:
       days: dagar
+      date_format: "%D dagar %H:%M:%S"
 
     index:
       description: Val på F-sektionen är då funktionärer och förtroendevalda blir valda. Se vilka poster som finns och sök idag.
@@ -16,7 +17,7 @@ sv:
         - post
       highlights: Vad betyder färger och markeringar?
       orange_posts: Orangefärgade poster är nämnd- eller styrelseposter.
-      star_posts: Poster markerade med * har inte något rekommenderat antal
+      star_posts: Poster markerade med * har inte något rekommenderat antal.
       x_posts: anger exakt maximalt antal.
 
     no_election:

--- a/db/migrate/20170227195000_add_translations_to_election.rb
+++ b/db/migrate/20170227195000_add_translations_to_election.rb
@@ -1,0 +1,16 @@
+class AddTranslationsToElection < ActiveRecord::Migration
+  def change
+    reversible do |dir|
+      dir.up do
+        Election.create_translation_table!({ title: :string, description: :text },
+                                           { migrate_data: true, remove_source_columns: true })
+      end
+
+      dir.down do
+        add_column(:council, :title, :string)
+        add_column(:council, :description, :text)
+        Election.drop_translation_table!(migrate_data: true)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -279,13 +279,23 @@ ActiveRecord::Schema.define(version: 20170823132130) do
   add_index "election_posts", ["election_id"], name: "index_election_posts_on_election_id", using: :btree
   add_index "election_posts", ["post_id"], name: "index_election_posts_on_post_id", using: :btree
 
+  create_table "election_translations", force: :cascade do |t|
+    t.integer  "election_id", limit: 4,     null: false
+    t.string   "locale",      limit: 255,   null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.string   "title",       limit: 255
+    t.text     "description", limit: 65535
+  end
+
+  add_index "election_translations", ["election_id"], name: "index_election_translations_on_election_id", using: :btree
+  add_index "election_translations", ["locale"], name: "index_election_translations_on_locale", using: :btree
+
   create_table "elections", force: :cascade do |t|
     t.datetime "open"
     t.datetime "close_general"
     t.boolean  "visible"
     t.string   "url",                 limit: 255
-    t.string   "title",               limit: 255
-    t.text     "description",         limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "candidate_mail",      limit: 65535

--- a/spec/mailers/meeting_mailer_spec.rb
+++ b/spec/mailers/meeting_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MeetingMailer, type: :mailer do
 
       mail = MeetingMailer.book_email(meeting)
 
-      mail.subject.should include(date_range(meeting.start_date, meeting.end_date))
+      mail.subject.should include(time_range(meeting.start_date, meeting.end_date))
       mail.subject.should include(Meeting.human_attribute_name(meeting.room))
       mail.subject.should include(Meeting.human_attribute_name(meeting.status))
     end
@@ -43,7 +43,7 @@ RSpec.describe MeetingMailer, type: :mailer do
 
       mail = MeetingMailer.update_email(meeting, meeting.user)
 
-      mail.subject.should include(date_range(meeting.start_date, meeting.end_date))
+      mail.subject.should include(time_range(meeting.start_date, meeting.end_date))
       mail.subject.should include(Meeting.human_attribute_name(meeting.room))
       mail.subject.should include(Meeting.human_attribute_name(meeting.status))
     end


### PR DESCRIPTION
* Election `title` and `description` can now be translated
* Updates some yml translations
* Adds translations to the countdown JS
* Removes padding from the default time/date format to avoid RSpec
errors