### PR TITLE
Event validation changes

### DIFF
--- a/app/controllers/admin/event_signups_controller.rb
+++ b/app/controllers/admin/event_signups_controller.rb
@@ -8,7 +8,6 @@ class Admin::EventSignupsController < Admin::BaseController
     if @event_signup.save
       redirect_to(admin_event_signup_path(@event), notice: alert_create(EventSignup))
     else
-      set_grids
       render :show, status: 422
     end
   end
@@ -17,7 +16,6 @@ class Admin::EventSignupsController < Admin::BaseController
     if @event_signup.update(event_signup_params)
       redirect_to(admin_event_signup_path(@event), notice: alert_update(EventSignup))
     else
-      set_grids
       render :show, status: 422
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,7 +20,7 @@ class Event < ApplicationRecord
 
   serialize :dress_code, Array
 
-  validates(:title, :description, :starts_at, :ends_at, :location, presence: true)
+  validates(:title_sv, :title_en, :description_sv, :description_en, :starts_at, :ends_at, :location_sv, presence: true)
 
   # Schedules notifications if event_signup is created or updated
   # This will lead to multiple notifications being queued if the event or signup

--- a/app/models/event_signup.rb
+++ b/app/models/event_signup.rb
@@ -8,7 +8,8 @@ class EventSignup < ApplicationRecord
   belongs_to :event, required: true
   has_many :event_users, through: :event
 
-  validates(:opens, :closes, :slots, presence: true)
+  validates(:opens, :closes, presence: true)
+  validates(:slots, presence: true, numericality: { greater_than: 0 })
   validates(:event, uniqueness: true)
   validate(:orders)
 

--- a/app/views/admin/event_signups/show.html.erb
+++ b/app/views/admin/event_signups/show.html.erb
@@ -39,10 +39,11 @@
       <div class="headline">
         <h3><%= t('.registered') %></h3>
       </div>
-
-      <%= render('/admin/event_users/attending_grid',
-                 grid: @attending,
-                 event: @event) %>
+      <% unless @attending.nil? %>
+        <%= render('/admin/event_users/attending_grid',
+                   grid: @attending,
+                   event: @event) %>
+      <% end %>
 
       <%= link_to t('.export'), export_admin_event_signup_path(@event, format: :csv) %>
       <hr>
@@ -51,10 +52,11 @@
         <h3><%= 'Reserver' %></h3>
       </div>
 
-      <%= render('/admin/event_users/attending_grid',
-                 grid: @reserves,
-                 event: @event) %>
-
+      <% unless @reserves.nil? %>
+        <%= render('/admin/event_users/attending_grid',
+                   grid: @reserves,
+                   event: @event) %>
+      <% end %>
       <%= link_to t('.export'), export_admin_event_signup_path(@event,
                                                                format: :csv,
                                                                list: 'reserves') %>

--- a/lib/tasks/tests_data.rake
+++ b/lib/tasks/tests_data.rake
@@ -112,11 +112,12 @@ namespace :db do
     # Events
     date = Time.zone.now.middle_of_day
     (1..10).each do |i|
-      event = Event.find_or_create_by!(short: %(E#{i}), title: %(Evenemang #{i}),
-                                       description: 'Detta kommer bli ett evenemang!',
-                                       starts_at: date, ends_at: date + 5.hours,
-                                       food: true, drink: true, location: 'Gasquesalen')
-      event.update!(short_en: event.short, title_en: %(Event #{i}), description_en: 'This will be an event!')
+      event = Event.create!(short_sv: %(E#{i}), title_sv: %(Evenemang #{i}),
+                            title_en: %(Event #{i}), description_sv: 'Detta kommer bli ett evenemang!',
+                            description_en: 'This will be an event!',
+                            starts_at: date, ends_at: date + 5.hours,
+                            food: true, drink: true, location: 'Gasquesalen')
+      event.update!(short_en: event.short)
       date = date + 1.days + [-3,-2,-1,0,1,2,3].sample.hours
     end
 

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe Admin::EventsController, type: :controller do
   describe 'POST #create' do
     it 'valid parameters' do
       attributes = { title_sv: 'Välkomstgasque!',
+                     title_en: 'Welcome gasque!',
                      description_sv: 'Det blir mat och dryck, waow!',
+                     description_en: 'There will be food and drinks, waow!',
                      location_sv: 'Kårhuset: Gasquesalen',
                      starts_at: 5.days.from_now,
                      ends_at: 7.days.from_now }

--- a/spec/controllers/introductions_controller_spec.rb
+++ b/spec/controllers/introductions_controller_spec.rb
@@ -118,16 +118,17 @@ RSpec.describe IntroductionsController, type: :controller do
     it 'only include translated events if other locale' do
       introduction = create(:introduction, start: 3.day.ago, stop: 3.day.from_now)
       category = create(:category, slug: :nollning)
-      swedish = create(:event, title: 'Svensk titel', starts_at: 1.day.ago)
+      swedish = create(:event, title_sv: 'Svensk titel', title_en: 'Engelsk titel', starts_at: 1.day.ago)
       swedish.categories << category
       swedish.save!
       english = create(:event, title: 'Översatt event', title_en: 'English title', starts_at: 1.day.ago)
+      swedish.title_sv.should eq('Svensk titel')
       english.title_en.should eq('English title')
       english.categories << category
       english.save!
 
       get :modal, params: { id: introduction.to_param, date: 1.day.ago.to_date, locale: :en }
-      assigns(:events).map(&:title_en).should eq(['English title'])
+      assigns(:events).map(&:title_en).should eq(['Engelsk titel', 'English title'])
     end
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,7 +1,9 @@
 FactoryGirl.define do
   factory :event do
-    title
-    description
+    title_sv { generate(:title) }
+    title_en { generate(:title) }
+    description_sv { generate(:description) }
+    description_en { generate(:description) }
     location
     starts_at { 10.days.from_now }
     ends_at { starts_at + 12.hours }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Event, type: :model do
 
   describe 'by locale' do
     it 'returns event depending on locale' do
-      create(:event, title: 'Ej översatt')
-      event_en = create(:event, title: 'Kommer att översättas')
-      event_en.update!(title_en: 'Translated')
+      create(:event, title_sv: 'Ej översatt', title_en: 'Not translated')
+      event_en = create(:event, title_sv: 'Kommer att översättas', title_en: 'Kommer att översättas')
+      event_en.update!(title_en: 'Will be translated')
 
       Event.by_locale.map(&:title).should eq(['Ej översatt',
                                               'Kommer att översättas'])
-      Event.by_locale(locale: 'en').map(&:title_en).should eq(['Translated'])
+      Event.by_locale(locale: 'en').map(&:title_en).should eq(['Not translated', 'Will be translated'])
       Event.by_locale(locale: 'nope').should be_empty
     end
   end


### PR DESCRIPTION
Adds more requirements on information when creating events. 

- Events now require both English and Swedish descriptions and titles. Specs also had to be changed to be changed to reflect the new requirements.
- An event can no longer have a negative amount of slots. Putting a negative amount of slots wasn't validated and gave an SQL error which is now solved.
- An `event_user` was sometimes created (through set_grids) even though the `event_signup` object never was which resulted in some errors. This should be fixed by only running `set_grids` when required.

**(The commits are somewhat weird on this branch due to a rebase.)**