### PR TITLE
Bug fixes: Notifications and MailAlias

### DIFF
--- a/app/assets/javascripts/mail_aliases.js
+++ b/app/assets/javascripts/mail_aliases.js
@@ -137,7 +137,7 @@
     form.submit(function(e) {
       e.preventDefault()
       var query = $('#alias-searchfield').val()
-      $.ajax('admin/mail_aliases/search',
+      $.ajax('/admin/mail_aliases/search',
              { method: 'GET'
              , data: { q: query }
              , error: console.log

--- a/app/models/event_user.rb
+++ b/app/models/event_user.rb
@@ -4,6 +4,7 @@ class EventUser < ApplicationRecord
   belongs_to :event, required: true, inverse_of: :event_users
   belongs_to :group
   has_one :event_signup, through: :event, required: true
+  has_many :notifications, as: :notifyable, dependent: :destroy
 
   # validates :user, uniqueness: { scope: :event }
   validate :uniqueness_validation

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/string/inflections'
+require 'sidekiq-unique-jobs'
+
+SidekiqUniqueJobs::Cli.start(ARGV)


### PR DESCRIPTION
* Adds callbacks so that notifications are destroyed when the associated `EventUser`/`EventSignup`/`Event` is destroyed. We will get `NilClass` exceptions without this. To avoid a lot of N+1 queries (loading `user` and updating the counter_cache for *every* notification that should be deleted), I had to do this manually.
* Changes `after_commit(:schedule_notifications)` to `after_save(:schedule_notifications)`. `after_commit` runs on `create`, `update` AND `destroy`, and there's really no need to schedule notifications for an event that's being deleted...
* Fixes incorrect paths in the mail alias javascript.

**Question**: Is the notification counter cache worth it? This workaround is not beautiful, and rails runs a lot of queries when we delete an event. Is there a better solution?