### PR TITLE
Devise config: Allow redirect to local files

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -51,4 +51,5 @@ DeviseTokenAuth.setup do |config|
   # the API. Since we let regular devise handle email confirmation, and have
   # disabled the confirmation routes for devise_token_auth, this can be set to anything.
   config.default_confirm_success_url = '/'
+  config.redirect_whitelist = ['/*', 'file://*']
 end


### PR DESCRIPTION
Updates the device token auth config to allow redirections to `file://`
urls that will be used in the app.