### PR TITLE
User validations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,8 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: true
   validates :email, format: { with: Devise::email_regexp }
-  validates :firstname, :lastname, presence: true
+  validates :firstname, :lastname, presence: true, format: { with: /\A[\p{L}\p{M}*\-\p{Zs}]{2,}\z/ }
+  validates :password_confirmation, presence: true, on: :create
   validate :food_validation
 
   # Associations

--- a/config/locales/gems/devise.sv.yml
+++ b/config/locales/gems/devise.sv.yml
@@ -28,16 +28,16 @@ sv:
     failure:
       already_authenticated: 'Du har redan loggat in.'
       inactive: 'Ditt konto har inte aktiverats ännu.'
-      invalid: 'Ogiltig epost eller lösenord.'
+      invalid: 'Ogiltig e-post eller lösenord.'
       invalid_token: 'Ogiltig token för autentisering.'
       last_attempt: "Du har ett försök till innan kontot låses."
       locked: 'Ditt konto är låst.'
-      not_found_in_database: "Ogitlig epost eller lösenord."
+      not_found_in_database: "Ogitlig e-post eller lösenord."
       timeout: 'Din session är inte längre giltig, vänligen logga in igen för att fortsätta.'
       unauthenticated: 'Du måste logga in eller skapa ett konto innan du kan fortsätta.'
       unconfirmed: 'Du måste bekräfta din e-postadress till ditt konto innan du kan fortsätta.'
       user:
-        not_found_in_database: 'Inget konto finns registrerat med angiven epostadress.'
+        not_found_in_database: 'Ogiltig e-post eller lösenord.'
     sessions:
       signed_in: 'Loggade in.'
       signed_out: 'Loggade ut.'

--- a/lib/tasks/tests_data.rake
+++ b/lib/tasks/tests_data.rake
@@ -52,6 +52,7 @@ namespace :db do
                                        firstname: 'Hilbert-Admin', lastname: 'Älg',
                                        program: 'Teknisk Fysik', start_year: 1996)
     admin.password = 'passpass'
+    admin.password_confirmation = 'passpass'
     admin.confirmed_at = Time.zone.now
     admin.member_at = Time.zone.now
     admin.save!
@@ -71,6 +72,7 @@ namespace :db do
     user.confirmed_at = Time.zone.now
     user.member_at = Time.zone.now
     user.password = 'passpass'
+    user.password_confirmation = 'passpass'
     user.save!
 
     puts 'You can sign in as USER with'

--- a/spec/factories/shared.rb
+++ b/spec/factories/shared.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   sequence(:description) { |n| "This describes the most impressive nr#{n}" }
   sequence(:email) { |n| "d.wessman#{n}@fsektionen.se" }
-  sequence(:lastname) { |n| "Wessman#{n}" }
+  sequence(:lastname, 'A') { |n| "Wessman#{n}" }
   sequence(:name) { |n| "David#{n}" }
-  sequence(:firstname) { |n| "David#{n}" }
+  sequence(:firstname, 'A') { |n| "David#{n}" }
   sequence(:phone) { |n| "070#{n}606122" }
   sequence(:student_id) { |n| "tfy54dw#{n}" }
   sequence(:title) { |n| "Titel#{n}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
-# encoding: UTF-8
 FactoryGirl.define do
   factory :user do
     email
     password '12345678'
+    password_confirmation '12345678'
     firstname
     lastname
     phone
@@ -19,6 +19,7 @@ FactoryGirl.define do
   factory :admin, class: 'User' do
     email
     password '12345678'
+    password_confirmation '12345678'
     firstname
     lastname
     phone

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,6 +14,38 @@ RSpec.describe User, type: :model do
     it { new_user.should validate_presence_of(:lastname) }
   end
 
+  describe 'name validation' do
+    it 'accepts names with at least two characters' do
+      user.lastname = 'Pi'
+      user.should be_valid
+    end
+
+    it 'does not accept names with less than 2 characters' do
+      user.lastname = 'F'
+      user.should be_invalid
+    end
+
+    it 'accepts unicode names with accents' do
+      user.lastname = 'Ναβροζίδης'
+      user.should be_valid
+    end
+
+    it 'accepts spaces and hyphens' do
+      user.lastname = 'Älg-Älg Älg'
+      user.should be_valid
+    end
+
+    it 'does not accept numbers' do
+      user.lastname = 'Nisse37'
+      user.should be_invalid
+    end
+
+    it 'does not accept special characters' do
+      user.lastname = 'Ka$$ör'
+      user.should be_invalid
+    end
+  end
+
   describe 'public instance methods' do
     context 'printing' do
       it 'print_id' do

--- a/spec/requests/api/authorization_spec.rb
+++ b/spec/requests/api/authorization_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Authentication', type: :request do
         post api_user_registration_path(firstname: 'Jakob',
                                         lastname: 'Navrozidis',
                                         email: 'jakob@fsektionen.se',
-                                        password: 'godtyckligt')
+                                        password: 'godtyckligt',
+                                        password_confirmation: 'godtyckligt')
       end.should change(User, :count).by(1)
 
       response.should have_http_status(200)
@@ -16,6 +17,18 @@ RSpec.describe 'Authentication', type: :request do
     it 'invalid parameters' do
       lambda do
         post api_user_registration_path(firstname: 'Jakob',
+                                        email: 'jakob@fsektionen.se',
+                                        password: 'godtyckligt',
+                                        password_confirmation: 'godtyckligt')
+      end.should change(User, :count).by(0)
+
+      response.should have_http_status(422)
+    end
+
+    it 'no password confirmation' do
+      lambda do
+        post api_user_registration_path(firstname: 'Jakob',
+                                        lastname: 'Navrozidis',
                                         email: 'jakob@fsektionen.se',
                                         password: 'godtyckligt')
       end.should change(User, :count).by(0)
@@ -30,7 +43,8 @@ RSpec.describe 'Authentication', type: :request do
       post api_user_registration_path(firstname: 'Jakob',
                                       lastname: 'Navrozidis',
                                       email: 'jakob@fsektionen.se',
-                                      password: 'godtyckligt')
+                                      password: 'godtyckligt',
+                                      password_confirmation: 'godtyckligt')
       # Mark email as confirmed
       User.last.update!(confirmed_at: Time.zone.now)
 
@@ -45,7 +59,8 @@ RSpec.describe 'Authentication', type: :request do
       post api_user_registration_path(firstname: 'Jakob',
                                       lastname: 'Navrozidis',
                                       email: 'jakob@fsektionen.se',
-                                      password: 'godtyckligt')
+                                      password: 'godtyckligt',
+                                      password_confirmation: 'godtyckligt')
       # Mark email as confirmed
       User.last.update!(confirmed_at: Time.zone.now)
 


### PR DESCRIPTION
Closes #664
Closes #661
Closes #659

Note the new format validation for `firstname` and `lastname`. It should accept all unicode names with at least two characters. It also forbids numbers and special characters (accents, hyphens and whitespaces not included).