### PR TITLE
API Bugs

### DIFF
--- a/app/serializers/api/event_serializer.rb
+++ b/app/serializers/api/event_serializer.rb
@@ -13,6 +13,10 @@ class Api::EventSerializer < ActiveModel::Serializer
     EventUser.eligible_user?(object, scope)
   end
 
+  def description
+    MarkdownHelper.markdown(object.description)
+  end
+
   class Api::ContactSerializer < ActiveModel::Serializer
     attributes(:id, :name)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -333,7 +333,7 @@ Fsek::Application.routes.draw do
       resources :event_users, only: [:create, :destroy]
     end
 
-    resources :push_devices, only: [:create, :destroy], param: :token
+    resource :push_devices, only: [:create, :destroy]
 
     resources :notifications, only: :index do
       get :unread


### PR DESCRIPTION
* Makes `PushDevices` a singular resource. We only use it for `create` and `delete`, and then we send the token through the JSON data. The `:id` attribute is never used.
* Adds markdown to `description` in the event serializer