### PR TITLE
Firefox matrix background

### DIFF
--- a/app/assets/javascripts/firefox.js
+++ b/app/assets/javascripts/firefox.js
@@ -1,0 +1,6 @@
+$(document).on('turbolinks:load', function(){
+  var FIREFOX = /Firefox/i.test(navigator.userAgent);
+  if (FIREFOX) {
+    $('body').addClass('gecko');
+  }
+});

--- a/app/assets/stylesheets/partials/_introduction_matrix.scss
+++ b/app/assets/stylesheets/partials/_introduction_matrix.scss
@@ -186,7 +186,8 @@ $matrix-item: rgba(255, 255, 255, 0.37);
     }
   }
 
-  .matrix-headline {
+  .matrix-headline,
+  .gecko-disclaimer {
     display: none;
   }
 
@@ -211,3 +212,19 @@ $matrix-item: rgba(255, 255, 255, 0.37);
   overflow: visible;
 }
 
+body.gecko {
+  .introduction {
+    .matrix-headline {
+      display: block;
+    }
+
+    .matrix {
+      border: none;
+      border-image: none;
+    }
+
+    .gecko-disclaimer {
+      display: block;
+    }
+  }
+}

--- a/app/views/introductions/matrix.html.erb
+++ b/app/views/introductions/matrix.html.erb
@@ -10,6 +10,9 @@
         <%= @introduction.title %>
       </small>
     </h1>
+    <span class="gecko-disclaimer">
+      <%= t('.gecko-disclaimer') %>
+    </span>
   </div>
 
   <div class="row matrix">

--- a/config/locales/views/introductions/introductions.sv.yml
+++ b/config/locales/views/introductions/introductions.sv.yml
@@ -58,6 +58,8 @@ sv:
     matrix:
       click_day_to_read_more: Tryck på en dag för att läsa mer
       description: Nollematrisen är ett schema för Nollningen vid F-sektionen inom TLTH. Här hittas tider, beskrivningar, eventuell anmälan och annat roligt för varje evenemang.
+      gecko-disclaimer: Nollematrisen ser ännu snyggare ut i en annan webbläsare, t.ex. Chrome och Safari.
+      gecko-title: Nollematris
       keywords:
         - nollning
         - schema


### PR DESCRIPTION
Did not work as intended, the window needed to be resized for the matrix to show. This will hide the background on Firefox like last year.