### PR TITLE
Api: Event bugs

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,12 +1,16 @@
 class Api::EventsController < Api::BaseController
-  load_permissions_and_authorize_resource
+  load_resource
 
   def index
+    authorize!(:index, :api_event)
+
     @events = Event.includes(:translations).between(params[:start], params[:end])
     render json: @events, namespace: '' # Use the same serializer as for the web calendar
   end
 
   def show
+    authorize!(:show, :api_event)
+
     render json: @event, scope: current_user # Event user included in serializer
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -55,6 +55,7 @@ class Ability
       can [:index, :look, :look_all], Notification, user_id: user.id
       can [:create, :destroy], PushDevice
       can :index, :start
+      can :read, :api_event
     end
 
     # Only for members of the Guild

--- a/app/serializers/api/event_serializer.rb
+++ b/app/serializers/api/event_serializer.rb
@@ -1,6 +1,8 @@
 class Api::EventSerializer < ActiveModel::Serializer
-  attributes(:id, :title, :description, :location, :starts_at, :ends_at, :all_day, :dot,
-             :drink, :food, :cash, :price, :dress_code, :can_signup, :event_user_count, :short)
+  include EventHelper
+
+  attributes(:id, :title, :description, :location, :starts_at, :ends_at, :all_day, :dot, :drink,
+             :food, :cash, :price, :dress_code, :can_signup, :event_user_count, :short, :user_types)
 
   belongs_to :contact
   has_one :event_signup
@@ -12,6 +14,12 @@ class Api::EventSerializer < ActiveModel::Serializer
   has_many :groups do
     if object.signup.present?
       scope.groups.merge(object.signup.selectable_groups)
+    end
+  end
+
+  def user_types
+    if object.signup.present? && object.signup.order.any?
+      event_user_types(object.signup, scope)
     end
   end
 
@@ -38,8 +46,14 @@ class Api::EventSerializer < ActiveModel::Serializer
   end
 
   class Api::EventUserSerializer < ActiveModel::Serializer
+    include EventHelper
+
     attributes(:id, :group_id, :answer, :user_type, :group_custom)
     attribute(:reserve) { object.reserve? }
+
+    def user_type
+      event_user_type(object.event_signup, object.user_type)
+    end
   end
 
   class Api::GroupSerializer < ActiveModel::Serializer

--- a/app/workers/event_signup_reminder_worker.rb
+++ b/app/workers/event_signup_reminder_worker.rb
@@ -16,7 +16,7 @@ class EventSignupReminderWorker
   end
 
   def notify(event_signup)
-    event_signup.event_users.each do |event_user|
+    event_signup.event_users.attending.each do |event_user|
       NotificationService.event_user(event_user, 'reminder')
     end
 


### PR DESCRIPTION
* Adds `user_types` to `Api::EventSerializer`
* Reserves no longer get reminders for events they can't attend

Also solves some authorization problems for `Api::Event` (`current_user` was `nil` some times)