### PR TITLE
Markdown: API Renderer

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -5,6 +5,10 @@ module MarkdownHelper
     MarkdownHelper.markdown(text)
   end
 
+  def self.markdown_api(text)
+    sanitize(api_renderer.render(text)) if text.present?
+  end
+
   def self.markdown(text)
     sanitize(markdown_renderer.render(text)) if text.present?
   end
@@ -40,6 +44,21 @@ module MarkdownHelper
                             tables: true,
                             underline: true,
                             highlight: true)
+  end
+
+  def self.api_renderer
+    options = {
+      hard_wrap: true,
+      link_attributes: { class: 'external', target: '_system' }
+    }
+    extensions = {
+      autolink: true, fenced_code_blocks: true, highlight: true,
+      lax_spacing: true, no_intra_emphasis: true, quote: true,
+      tables: true, underline: true
+    }
+
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(options),
+                            extensions)
   end
 
   def self.sanitize(input)

--- a/app/serializers/api/event_serializer.rb
+++ b/app/serializers/api/event_serializer.rb
@@ -32,7 +32,7 @@ class Api::EventSerializer < ActiveModel::Serializer
   end
 
   def description
-    MarkdownHelper.markdown(object.description)
+    MarkdownHelper.markdown_api(object.description)
   end
 
   class Api::ContactSerializer < ActiveModel::Serializer

--- a/app/serializers/api/news_serializer.rb
+++ b/app/serializers/api/news_serializer.rb
@@ -5,7 +5,7 @@ class Api::NewsSerializer < ActiveModel::Serializer
   belongs_to(:user)
 
   def content
-    MarkdownHelper.markdown(object.content)
+    MarkdownHelper.markdown_api(object.content)
   end
 
   def image

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -1,6 +1,6 @@
 class MessageSerializer < ActiveModel::Serializer
   attributes(:id, :by_admin, :updated_at)
-  attribute(:text) { MarkdownHelper.markdown(object.content) }
+  attribute(:text) { MarkdownHelper.markdown_api(object.content) }
   attribute(:day) { object.created_at.to_date }
   attribute(:time) { object.created_at.strftime('%H:%M') }
 


### PR DESCRIPTION
Automatically adds `class='external' target='_system'` to links, so that they can be opened in the app.