### PR TITLE
CSS: Fix overflow issue

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,4 +32,5 @@ body {
 
 .content {
   flex: 1;
+  max-width: 100%;
 }


### PR DESCRIPTION
A small change that prevents the main container from overflowing and thereby making the header and footer look ugly. Should have been fixed a year ago...