### PR TITLE
Devise Token Auth: Allow tokens to be reused

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -3,7 +3,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.


### PR DESCRIPTION
Allows the same token to be used multiple times through the API. This is
a _little_ bit less secure than the current solution with request-unique tokens,
but a _lot_ more practical. The old setting caused some problems when
the F-app was used on mobile networks with weak reception (or eduroam in MH), and
required re-authentication with e-mail and password way to often for
some users.