### PR TITLE
Song api

### DIFF
--- a/app/controllers/api/songs_controller.rb
+++ b/app/controllers/api/songs_controller.rb
@@ -1,0 +1,16 @@
+class Api::SongsController < Api::BaseController
+  load_permissions_and_authorize_resource
+
+  def index
+    @songs = Song.all
+    render json: @songs,
+    each_serializer: Api::SongSerializer::Multiple # Returns id and title
+  end
+
+  def show
+    @song = Song.find(params[:id])
+    Song.increment_counter(:visits, @song)
+    render json: @song,
+    serializer: Api::SongSerializer::Single # Returns all relevant fields
+  end
+end

--- a/app/serializers/api/song_serializer.rb
+++ b/app/serializers/api/song_serializer.rb
@@ -1,0 +1,14 @@
+class Api::SongSerializer < ActiveModel::Serializer
+
+  class Api::SongSerializer::Multiple < ActiveModel::Serializer
+    attributes(:id, :title)
+  end
+
+  class Api::SongSerializer::Single < ActiveModel::Serializer
+    attributes(:id, :title, :author, :melody, :content)
+    
+    def content
+      MarkdownHelper.markdown_api(object.content)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -351,6 +351,8 @@ Fsek::Application.routes.draw do
 
     resources :news, only: :index
     resources :start, only: :index
+
+    resources :songs, only: [:index, :show]
   end
 
   get 'proposals/form' => 'proposals#form'


### PR DESCRIPTION
Adds a song endpoint to the api which allows app users to view the song collection.

**The following endpoints are introduced:**
- /songs
Returns a list of all songs with titles and corresponding ids.
- /songs/_id_
Returns information about the song corresponding to the id _id_.

Requires a logged in user.