### PR TITLE
Car Rental update: Terms & Bans

### DIFF
--- a/app/assets/stylesheets/partials/_start_page.scss
+++ b/app/assets/stylesheets/partials/_start_page.scss
@@ -57,4 +57,9 @@
   &.left {
     margin-bottom: 20px;
   }
+
+  .alert {
+    margin-left: 15px;
+    margin-right: 15px;
+  }
 }

--- a/app/assets/stylesheets/style/global.scss
+++ b/app/assets/stylesheets/style/global.scss
@@ -155,8 +155,3 @@ a {
   margin-bottom: 20px;
   margin-top: 20px;
 }
-
-.alert {
-  margin-left: 15px;
-  margin-right: 15px;
-}

--- a/app/controllers/admin/car_bans_controller.rb
+++ b/app/controllers/admin/car_bans_controller.rb
@@ -1,0 +1,49 @@
+class Admin::CarBansController < Admin::BaseController
+  load_permissions_and_authorize_resource
+
+  def index
+    @grid = initialize_grid(CarBan, order: :created_at)
+  end
+
+  def new
+    @car_ban = CarBan.new
+  end
+
+  def edit
+    @car_ban = CarBan.find(params[:id])
+  end
+
+  def create
+    @car_ban = CarBan.new(car_ban_params)
+    @car_ban.creator = current_user
+
+    if @car_ban.save
+      redirect_to admin_car_bans_path, notice: alert_create(CarBan)
+    else
+      render :new, status: 422
+    end
+  end
+
+  def update
+    @car_ban = CarBan.find(params[:id])
+
+    if @car_ban.update(car_ban_params)
+      redirect_to admin_car_bans_path, notice: alert_update(CarBan)
+    else
+      render :edit, status: 422
+    end
+  end
+
+  def destroy
+    car_ban = CarBan.find(params[:id])
+    car_ban.destroy!
+
+    redirect_to admin_car_bans_path, notice: alert_destroy(CarBan)
+  end
+
+  private
+
+  def car_ban_params
+    params.require(:car_ban).permit(:user_id, :reason)
+  end
+end

--- a/app/controllers/rents_controller.rb
+++ b/app/controllers/rents_controller.rb
@@ -1,4 +1,3 @@
-# encoding:UTF-8
 class RentsController < ApplicationController
   load_permissions_and_authorize_resource
   before_action :load_terms, only: [:new, :edit, :create, :update, :main, :index]
@@ -25,7 +24,7 @@ class RentsController < ApplicationController
   end
 
   def create
-    if RentService.reservation(current_user, @rent)
+    if RentService.reservation(current_user, @rent, @terms)
       redirect_to rent_path(@rent), notice: alert_create(Rent)
     else
       render :new, status: 422
@@ -54,7 +53,7 @@ class RentsController < ApplicationController
 
   def rent_params
     params.require(:rent).permit(:d_from, :d_til, :purpose,
-                                 :council_id, :user_id)
+                                 :council_id, :user_id, :terms)
   end
 
   def load_terms

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -63,6 +63,12 @@ class Ability
       can [:show], Album
 
       can [:show, :overview, :new, :create], Rent
+
+      if user.car_ban.present?
+        cannot(:create, Rent, council_id: nil)
+        can(:new, Rent, council_id: nil)
+      end
+
       can [:edit, :update, :destroy], Rent, user_id: user.id
       can [:read, :mail], Contact
       can :read, Document

--- a/app/models/car_ban.rb
+++ b/app/models/car_ban.rb
@@ -1,0 +1,7 @@
+class CarBan < ApplicationRecord
+  belongs_to :user
+  belongs_to :creator, class_name: 'User', foreign_key: :creator_id
+
+  validates :user, uniqueness: true
+  validates :reason, presence: true
+end

--- a/app/models/rent.rb
+++ b/app/models/rent.rb
@@ -13,6 +13,8 @@ class Rent < ApplicationRecord
   scope :ascending, -> { order(d_from: :asc) }
   scope :from_date, ->(from) { where('d_from >= ?', from) }
 
+  attr_accessor :terms
+
   def member?
     user.try(:member?)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ApplicationRecord
   has_many :meetings
   has_many :notifications, dependent: :destroy, inverse_of: :user
   has_many :push_devices, dependent: :destroy
+  has_one :car_ban
 
   mount_uploader :avatar, AttachedImageUploader, mount_on: :avatar_file_name
 

--- a/app/views/admin/car_bans/_form.html.erb
+++ b/app/views/admin/car_bans/_form.html.erb
@@ -1,0 +1,17 @@
+<%= simple_form_for([:admin, car_ban]) do |f| %>
+  <%= f.association :user, collection: User.members,
+                           label_method: :print_program,
+                           required: true,
+                           input_html: {class: 'select2'} %>
+
+  <%= f.input :reason, input_html: { rows: 3 } %>
+
+  <%= f.button :submit %>
+  <%= link_to t('.index'), admin_car_bans_path, class: 'btn secondary' %>
+
+  <% if car_ban.persisted? %>
+    <%= link_to(t('.destroy'), admin_car_ban_path(car_ban),
+                               method: :delete,
+                               class: 'btn danger pull-right') %>
+  <% end %>
+<% end %>

--- a/app/views/admin/car_bans/edit.html.erb
+++ b/app/views/admin/car_bans/edit.html.erb
@@ -1,0 +1,7 @@
+<div class='col-md-8 col-md-offset-2 col-sm-12 reg-page'>
+  <div class="headline">
+    <h1><%= title(t('.title')) %></h1>
+  </div>
+
+  <%= render 'form', car_ban: @car_ban %>
+</div>

--- a/app/views/admin/car_bans/index.html.erb
+++ b/app/views/admin/car_bans/index.html.erb
@@ -1,0 +1,26 @@
+<div class="headline">
+  <h2><%= title(t('.title')) %></h2>
+</div>
+
+<div class="col-md-2 col-sm-12">
+  <%= link_to t('.new'), new_admin_car_ban_path, class: 'btn primary' %>
+  <%= link_to t('.rents'), admin_rents_path, class: 'btn secondary' %>
+</div>
+
+<div class="col-md-10 col-sm-12">
+  <%= grid(@grid, show_filters: :no) do |g|
+    g.column(name: CarBan.human_attribute_name(:user), attribute: 'firstname', assoc: :user) do |car_ban|
+      link_to car_ban.user, user_path(car_ban.user)
+    end
+    g.column(name: CarBan.human_attribute_name(:created_at), attribute: 'created_at')
+    g.column(name: CarBan.human_attribute_name(:creator), attribute: 'firstname', assoc: :creator) do |car_ban|
+      car_ban.creator
+    end
+    g.column(name: t('global.edit')) do |car_ban|
+      link_to t('global.edit'), edit_admin_car_ban_path(car_ban)
+    end
+    g.column(name: t('global.destroy')) do |car_ban|
+      link_to t('global.destroy'), admin_car_ban_path(car_ban), method: :delete
+    end
+  end -%>
+</div>

--- a/app/views/admin/car_bans/new.html.erb
+++ b/app/views/admin/car_bans/new.html.erb
@@ -1,0 +1,7 @@
+<div class='col-md-8 col-md-offset-2 col-sm-12 reg-page'>
+  <div class="headline">
+    <h1><%= title(t('.title')) %></h1>
+  </div>
+
+  <%= render 'form', car_ban: @car_ban %>
+</div>

--- a/app/views/admin/rents/index.html.erb
+++ b/app/views/admin/rents/index.html.erb
@@ -7,6 +7,7 @@
     <%= link_to(t('.clear_search'), admin_rents_path, class: 'btn primary') %><br>
     <%= link_to(t('.new_rent'), new_admin_rent_path, class: 'btn secondary') %> <br>
     <%= link_to(t('.startpage'), rents_path, class: 'btn secondary') %> <br>
+    <%= link_to(t('.car_bans'), admin_car_bans_path, class: 'btn secondary') %>
   </div>
 </div>
 

--- a/app/views/layouts/_content.html.erb
+++ b/app/views/layouts/_content.html.erb
@@ -13,6 +13,6 @@
     </div>
   <% end %>
 
-<%= yield %>
+  <%= yield %>
 
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,11 +9,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <%= stylesheet_link_tag 'application',
-                            media: 'all',
-                            'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application',
-                               'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= csrf_meta_tags %>
     <%= render '/layouts/favicon' %>
   </head>
@@ -29,7 +26,13 @@
 
     <%= yield :pre_content %>
 
-    <%= render 'layouts/content' %>
+    <% if controller_name == 'static_pages' && action_name == 'index' %>
+      <div class="start-page">
+        <%= render 'layouts/content' %>
+      </div>
+    <% else %>
+      <%= render 'layouts/content' %>
+    <% end %>
 
     <%= render 'layouts/copyright' %>
 

--- a/app/views/rents/_car_bans.html.erb
+++ b/app/views/rents/_car_bans.html.erb
@@ -1,0 +1,7 @@
+<% if car_ban.present? %>
+  <div class="alert alert-danger">
+    <b><%= t('.banned') %></b>
+    <%= t('.reason') %> <%= car_ban.reason %>
+    <%= t('.for_councils') %>
+  </div>
+<% end %>

--- a/app/views/rents/_form.html.erb
+++ b/app/views/rents/_form.html.erb
@@ -4,9 +4,10 @@
   <% if rent.errors[:user].present? %>
     <p><%= link_to(t('.edit_user_information'), edit_own_user_path,
                                                 target: :blank_p) %></p>
+
+    <%= render 'renter_table', user: rent.user, rent: rent %>
   <% end %>
 
-  <%= render 'renter_table', user: rent.user, rent: rent %>
 
   <% if (overlap = rent.overlap).try(:any?) %>
     <span class='overlapping-date'><%= t('.overlaps_with') %></span>
@@ -35,11 +36,13 @@
   <% end %>
 
   <% if @terms.present? %>
+    <strong><%= t('.terms') %></strong>
     <span class="rent terms">
-    <%= t('.agree_to_terms') %>
-    <%= link_to(document_path(@terms), target: 'blank_p') do %>
-      <%= fa_icon('paperclip') %> <%= t('.terms') %>.
-    <% end %>
+      <%= t('.read_terms') %>
+      <strong>
+        <%= link_to(t('.the_terms'), document_path(@terms), target: 'blank_p') %>
+      </strong>
+      <%= f.input :terms, as: :boolean, required: true, label: t('.agree_to_terms') %>
     </span>
     <br>
   <% end %>

--- a/app/views/rents/index.html.erb
+++ b/app/views/rents/index.html.erb
@@ -33,5 +33,9 @@
 </div>
 
 <div class='col-md-9 col-xs-12'>
+  <% if current_user.present? %>
+    <%= render 'car_bans', car_ban: current_user.car_ban %>
+  <% end %>
+
   <div id='bilkalender'></div>
 </div>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -13,7 +13,7 @@
   </div>
 <% end %>
 
-<div class="col-md-7 col-sm-12 col-xs-12 start-page left">
+<div class="col-md-7 col-sm-12 col-xs-12 left">
   <% if @start_page.election_view.present? %>
     <%= render 'countdown', election_view: @start_page.election_view %>
   <% end %>

--- a/config/locales/defaults/unauthorized.sv.yml
+++ b/config/locales/defaults/unauthorized.sv.yml
@@ -7,19 +7,19 @@ sv:
 
     update:
       project: "Inte tillåten att uppdatera projektet."
-      rent: Bilbokning är endast till för sektionens medlemmar.
+      rent: Inte auktoriserad att skapa bilbokningar.
 
     new:
       candidate: Kandideringar till val är endast för medlemmar vid sektionen.
       nomination: Nomineringar till val är endast för medlemmar vid sektionen.
-      rent: Bilbokning är endast till för sektionens medlemmar.
+      rent: Inte auktoriserad att skapa bilbokningar.
 
     show:
       album: Bildgalleriet är endast till för sektionens medlemmar.
       candidate: Kandideringar till val är endast för medlemmar vid sektionen.
-      rent: Bilbokning är endast till för sektionens medlemmar.
+      rent: Inte auktoriserad att skapa bilbokningar.
       cafe_shift: Måste vara inloggad för att skriva upp dig för att arbeta i Hilbert Café.
 
     index:
       candidate: Kandideringar till val är endast för medlemmar vid sektionen.
-      rent: Bilbokning är endast till för sektionens medlemmar.
+      rent: Inte auktoriserad att skapa bilbokningar.

--- a/config/locales/models/car_ban.sv.yml
+++ b/config/locales/models/car_ban.sv.yml
@@ -1,0 +1,12 @@
+sv:
+  activerecord:
+    models:
+      car_ban:
+        one: Spärr
+        other: Spärrar
+    attributes:
+      car_ban:
+        user: Användare
+        creator: Skapad av
+        reason: Anledning
+        created_at: Skapad

--- a/config/locales/models/rent.sv.yml
+++ b/config/locales/models/rent.sv.yml
@@ -9,6 +9,7 @@ sv:
         overlap: överlappar med en annan bokning
         overlap_council: överlappar med en annan utskottsbokning
         overlap_overbook: överlappar med en bokning som det är mindre än 5 dagar till
+        terms: Du måste godkänna bokningsavtalet
 
       active: aktiv
       confirmed: bekräftad

--- a/config/locales/views/admin/car_bans/car_bans_admin.sv.yml
+++ b/config/locales/views/admin/car_bans/car_bans_admin.sv.yml
@@ -1,0 +1,17 @@
+sv:
+  admin:
+    car_bans:
+      index:
+        title: Bilbokning - Spärra användare
+        new: Ny spärr
+        rents: Alla bilbokningar
+
+      new:
+        title: Spärra användare
+
+      edit:
+        title: Redigera spärrning
+
+      form:
+        index: Alla bokningsspärrar
+        destroy: Förinta spärr

--- a/config/locales/views/admin/rents/rents_admin.sv.yml
+++ b/config/locales/views/admin/rents/rents_admin.sv.yml
@@ -13,6 +13,7 @@ sv:
         new_rent: Ny bilbokning
         startpage: Startsida för bilbokning
         title: Bilbokning - administration
+        car_bans: Spärra användare
 
       show:
         admin_index: Startsida administration

--- a/config/locales/views/rents/rents.sv.yml
+++ b/config/locales/views/rents/rents.sv.yml
@@ -8,6 +8,9 @@ sv:
       only_for_council: får endast göras åt utskottet
       overlaps_with: 'Överlappar med:'
       terms: Bokningsavtal
+      the_terms: bokningsavtalet.
+      read_terms: Läs igenom och godkänn
+      agree_to_terms: Jag godkänner bokningsavtalet
 
     index:
       ask_question: Ställ ny fråga
@@ -52,3 +55,8 @@ sv:
     new:
       index: Startsida för bilbokning
       title: Ny bilbokning
+
+    car_bans:
+      banned: Du är spärrad från bilbokningstjänsten.
+      reason: "Anledning: "
+      for_councils: Utskottsbokning kan fortfarande genomföras.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,8 @@ Fsek::Application.routes.draw do
       resources :rents, path: :bilbokning, except: :edit do
         get :preview, path: :visa, on: :member
       end
+
+      resources :car_bans, path: :bilsparr, except: :show
     end
 
     resources :rents, path: :bilbokning do

--- a/db/migrate/20180119115000_create_car_bans.rb
+++ b/db/migrate/20180119115000_create_car_bans.rb
@@ -1,0 +1,12 @@
+class CreateCarBans < ActiveRecord::Migration[5.0]
+  def change
+    create_table :car_bans do |t|
+      t.references :user, foreign_key: true, index: true, unique: true
+      t.references :creator, index: true
+      t.text :reason
+      t.timestamps null: false
+    end
+
+    add_foreign_key :car_bans, :users, column: :creator_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170905182100) do
+ActiveRecord::Schema.define(version: 20180119115000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,6 +148,16 @@ ActiveRecord::Schema.define(version: 20170905182100) do
     t.index ["election_id"], name: "index_candidates_on_election_id", using: :btree
     t.index ["post_id"], name: "index_candidates_on_post_id", using: :btree
     t.index ["user_id"], name: "index_candidates_on_user_id", using: :btree
+  end
+
+  create_table "car_bans", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "creator_id"
+    t.text     "reason"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_car_bans_on_creator_id", using: :btree
+    t.index ["user_id"], name: "index_car_bans_on_user_id", using: :btree
   end
 
   create_table "categories", force: :cascade do |t|
@@ -906,6 +916,8 @@ ActiveRecord::Schema.define(version: 20170905182100) do
   add_foreign_key "candidates", "elections"
   add_foreign_key "candidates", "posts"
   add_foreign_key "candidates", "users"
+  add_foreign_key "car_bans", "users"
+  add_foreign_key "car_bans", "users", column: "creator_id"
   add_foreign_key "categorizations", "categories"
   add_foreign_key "election_posts", "elections"
   add_foreign_key "election_posts", "posts"

--- a/spec/factories/rents.rb
+++ b/spec/factories/rents.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     d_til { Time.zone.now + 10.days + 12.hours }
     aktiv true
     status :confirmed
+    terms '1'
 
     # Override after_create callbacks.
     after(:build) do |rent|

--- a/spec/services/rent_service_spec.rb
+++ b/spec/services/rent_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RentService do
       rent = build(:rent, user: user)
 
       lambda do
-        RentService.reservation(user, rent).should be_truthy
+        RentService.reservation(user, rent, true).should be_truthy
       end.should change(Rent, :count).by(1)
     end
 
@@ -16,7 +16,7 @@ RSpec.describe RentService do
       rent = build(:rent, user: nil, d_from: nil)
 
       lambda do
-        RentService.reservation(user, rent).should be_falsey
+        RentService.reservation(user, rent, true).should be_falsey
       end.should change(Rent, :count).by(0)
     end
   end
@@ -28,7 +28,7 @@ RSpec.describe RentService do
       council_rent = build(:rent, :with_council, user: user)
 
       lambda do
-        RentService.reservation(user, council_rent).should be_truthy
+        RentService.reservation(user, council_rent, true).should be_truthy
       end.should change(Rent, :count).by(1)
 
       overbook.reload
@@ -41,7 +41,7 @@ RSpec.describe RentService do
       rent = build(:rent, user: user)
 
       lambda do
-        RentService.reservation(user, rent).should be_falsey
+        RentService.reservation(user, rent, true).should be_falsey
       end.should change(Rent, :count).by(0)
 
       overbook.reload
@@ -54,7 +54,7 @@ RSpec.describe RentService do
       council_rent = build(:rent, :with_council, user: user)
 
       lambda do
-        RentService.reservation(user, council_rent).should be_falsey
+        RentService.reservation(user, council_rent, true).should be_falsey
       end.should change(Rent, :count).by(0)
 
       overbook.reload


### PR DESCRIPTION
The following functions have been added by requests from the Car Supervisor and The Treasury:

* The rental terms are now more visible, and a 'I agree' checkbox needs to be checked in the rental form.
* Users can be banned from the rental service.

This PR also fixes a design issue for the alerts.

Specs will come in a later PR (wrong order, I know...)