### PR TITLE
Fix rollbar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ GEM
     roadie-rails (1.3.0)
       railties (>= 3.0, < 5.3)
       roadie (~> 3.1)
-    rollbar (2.15.6)
+    rollbar (2.15.5)
       multi_json
     routing-filter (0.6.1)
       actionpack (>= 4.2, < 5.2)


### PR DESCRIPTION
The latest version is broken: https://github.com/rollbar/rollbar-gem/issues/713
Downgrading until a fix is released.