### PR TITLE
Added event signup closing notification, closes #811

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,7 +48,7 @@ class UsersController < ApplicationController
     params.require(:user).permit(:firstname, :lastname, :program, :start_year,
                                  :avatar, :student_id, :phone, :display_phone,
                                  :remove_avatar, :food_custom, :notify_messages,
-                                 :notify_event_users, food_preferences: [])
+                                 :notify_event_users, :notify_event_closing, food_preferences: [])
   end
 
   def account_params

--- a/app/helpers/admin/event_signups_helper.rb
+++ b/app/helpers/admin/event_signups_helper.rb
@@ -54,6 +54,14 @@ module Admin::EventSignupsHelper
       end
     end
 
+    if signup.sent_closing.present?
+      content << content_tag(:span, class: 'event-reminder') do
+        safe_join([fa_icon('bell'),
+                   I18n.t('model.event_signup.closing_was_sent',
+                          date: localize(signup.sent_closing))])
+      end
+    end
+
     safe_join(content)
   end
 

--- a/app/models/events/event_signup.rb
+++ b/app/models/events/event_signup.rb
@@ -7,6 +7,7 @@ class EventSignup < ApplicationRecord
   acts_as_paranoid
   belongs_to :event, required: true
   has_many :event_users, through: :event
+  has_many :notifications, as: :notifyable, dependent: :destroy
 
   validates(:opens, :closes, presence: true)
   validates(:slots, presence: true, numericality: { greater_than: 0 })
@@ -25,6 +26,7 @@ class EventSignup < ApplicationRecord
 
   scope :reminder_not_sent, -> { where(sent_reminder: nil) }
   scope :position_not_sent, -> { where(sent_position: nil) }
+  scope :closing_not_sent, -> { where(sent_closing: nil) }
   scope :closed, -> { where('closes < :current', current: Time.zone.now) }
 
   serialize :group_types, Array

--- a/app/models/notifications/notification.rb
+++ b/app/models/notifications/notification.rb
@@ -1,6 +1,6 @@
 class Notification < ApplicationRecord
-  enum(event_users: [:reminder, :position])
-  ALLOWED = { 'EventUser' => event_users }.freeze
+  enum(event_users: [:reminder, :position], event_signup: [:closing])
+  ALLOWED = { 'EventUser' => event_users, 'EventSignup' => event_signups }.freeze
 
   belongs_to :user, required: true, inverse_of: :notifications
   belongs_to :notifyable, polymorphic: true, required: true
@@ -51,7 +51,7 @@ class Notification < ApplicationRecord
   end
 
   def send_push
-    if notifyable_type == 'EventUser' && user.notify_event_users
+    if (notifyable_type == 'EventUser' && user.notify_event_users) || notifyable_type == 'EventSignup'
       PushService.push(data, user)
     end
   end

--- a/app/models/notifications/notification_data.rb
+++ b/app/models/notifications/notification_data.rb
@@ -7,6 +7,8 @@ class NotificationData
 
     if @notification.notifyable_type == 'EventUser'
       init_event_user
+    elsif @notification.notifyable_type == 'EventSignup'
+      init_closing
     end
   end
 
@@ -57,5 +59,12 @@ class NotificationData
     @body = I18n.t('model.notification_data.remind_soon_starting',
                    event: @notifyable.event,
                    time: I18n.l(@notifyable.event.starts_at))
+  end
+
+  def init_closing
+    @icon = 'calendar'
+    @body = I18n.t('model.notification_data.remind_signup_soon_closing',
+                   event: @notifyable.event,
+                   time: I18n.l(@notifyable.event.signup.closes))
   end
 end

--- a/app/services/push_service.rb
+++ b/app/services/push_service.rb
@@ -1,7 +1,6 @@
 class PushService
   def self.push(data_object, users)
     app = Rpush::Gcm::App.find_by!(name: "firebase")
-
     push_android(data_object, app, users)
     push_ios(data_object, app, users)
   end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -33,6 +33,7 @@
   <div class="input-group margin-bottom-10">
     <%= f.input :notify_event_users %>
     <%= f.input :notify_messages %>
+    <%= f.input :notify_event_closing %>
   </div>
 
   <%= f.button :submit, id: 'user-info-submit' %>

--- a/app/workers/event_signup_closing_reminder_worker.rb
+++ b/app/workers/event_signup_closing_reminder_worker.rb
@@ -1,0 +1,26 @@
+class EventSignupClosingReminderWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :while_executing, unique_expiration: 60 * 24
+
+  def perform(event_signup_id, time_until)
+    event_signup = EventSignup.includes(:event_users).find(event_signup_id)
+    notify(event_signup) if notifyable(event_signup, time_until)
+  end
+
+  private
+
+  def notifyable(event_signup)
+    event_signup.present? && event_signup.sent_closing.nil?
+  end
+
+  def notify(event_signup)
+    if event_signup.slots > event_signup.event_users.count
+      attending_user_id = event_signup.event_users.pluck(:user_id)
+      notify_users = User.where(notify_event_closing: true).where.not(id: attending_user_id)
+      notify_users.each do |user|
+        NotificationService.event_signup(event_signup, 'closing', user)
+      end
+      event_signup.update!(sent_closing: Time.zone.now)
+    end
+  end
+end

--- a/config/locales/models/notification_data.yml
+++ b/config/locales/models/notification_data.yml
@@ -3,4 +3,5 @@ sv:
     notification_data:
       attending: "Du har fått en plats till **%{event}**!"
       remind_soon_starting: "Du är anmäld till **%{event}** som startar **%{time}**."
+      remind_signup_soon_closing: "Anmälan till **%{event}** stänger **%{time}** och det finns fortfarande platser kvar."
       reserve_position: "Du fick tyvärr ingen plats till **%{event}**. Du ligger just nu på reservlistan."

--- a/config/locales/models/user.sv.yml
+++ b/config/locales/models/user.sv.yml
@@ -52,4 +52,5 @@ sv:
         unconfirmed_email: Obekräftad epost
         username: Användarnamn
         notify_event_users: Push-notiser för eventanmälan
+        notify_event_closing: Push-notiser två timmar före eventanmälan stänger
         notify_messages: Push-notiser för meddelanden

--- a/db/migrate/20180512180902_add_column_to_user_notification_settings.rb
+++ b/db/migrate/20180512180902_add_column_to_user_notification_settings.rb
@@ -1,0 +1,5 @@
+class AddColumnToUserNotificationSettings < ActiveRecord::Migration[5.0]
+  def change
+    add_column(:users, :notify_event_closing, :boolean, null: false, default: false)
+  end
+end

--- a/db/migrate/20180513125456_add_column_to_add_reminder_dates_to_event_signup.rb
+++ b/db/migrate/20180513125456_add_column_to_add_reminder_dates_to_event_signup.rb
@@ -1,0 +1,5 @@
+class AddColumnToAddReminderDatesToEventSignup < ActiveRecord::Migration[5.0]
+  def change
+    add_column(:event_signups, :sent_closing, :datetime)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180428080147) do
+ActiveRecord::Schema.define(version: 20180513125456) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -355,6 +355,7 @@ ActiveRecord::Schema.define(version: 20180428080147) do
     t.string   "group_types"
     t.datetime "sent_reminder"
     t.datetime "sent_position"
+    t.datetime "sent_closing"
     t.index ["deleted_at"], name: "index_event_signups_on_deleted_at", using: :btree
     t.index ["event_id"], name: "index_event_signups_on_event_id", using: :btree
   end
@@ -906,6 +907,7 @@ ActiveRecord::Schema.define(version: 20180428080147) do
     t.integer  "notifications_count",                default: 0,       null: false
     t.boolean  "notify_event_users",                 default: true,    null: false
     t.boolean  "notify_messages",                    default: true,    null: false
+    t.boolean  "notify_event_closing",               default: false,   null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/lib/tasks/tests_data.rake
+++ b/lib/tasks/tests_data.rake
@@ -162,5 +162,8 @@ namespace :db do
                             author: 'Gurra',
                             category: 'Visor',
                             content: 'Sverige är Sverige och Sverige är bra!')
+
+    # Notifications
+    Rpush::Gcm::App.find_or_create_by!(name: :firebase, auth_key: :test)
   end
 end


### PR DESCRIPTION
If an event is not full two hours before the event signup closes, a notification will be sent out to all users that is not signed up to the event and that have selected this feature on the user settings page, which by default is set to `false`, reminding them that the signup soon closes and that there still are slots available.