### PR TITLE
Event signup closing notification changes

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -3,7 +3,7 @@ class Api::UsersController < Api::BaseController
 
   def update
     @user = current_user
-    
+
     if @user.update(user_params)
       render json: {}, status: :ok
     else
@@ -17,6 +17,6 @@ class Api::UsersController < Api::BaseController
     params.require(:user).permit(:firstname, :lastname, :program, :start_year,
                                  :avatar, :student_id, :phone, :display_phone,
                                  :remove_avatar, :food_custom, :notify_messages,
-                                 :notify_event_users, food_preferences: [])
+                                 :notify_event_users, :notify_event_closing, food_preferences: [])
   end
 end

--- a/app/serializers/api/notification_serializer.rb
+++ b/app/serializers/api/notification_serializer.rb
@@ -4,7 +4,7 @@ class Api::NotificationSerializer < ActiveModel::Serializer
   attribute(:event_id)
 
   def event_id
-    if object.notifyable_type == 'EventUser'
+    if object.notifyable_type == 'EventUser' || object.notifyable_type == 'EventSignup'
       object.notifyable.event.id
     end
   end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -25,7 +25,7 @@ class NotificationService
 
   # Schedule notification for users position on an event signup,
   # a reminder half an hour before the event start as well as a
-  # reminder two hours before an event signup closes.
+  # reminder twelve hours before an event signup closes.
   def self.event_schedule_notifications(event)
     return unless event.present? && event.signup.present?
 
@@ -37,7 +37,7 @@ class NotificationService
     # Pass the diff between reminder and event start.
     notify_start(event)
 
-    # Remind not signed up users 2 hours before event signup closing.
+    # Remind not signed up users 12 hours before event signup close.
     # Make sure that the event isen't full.
     notify_closing(event)
   end
@@ -56,7 +56,7 @@ class NotificationService
 
   def self.notify_closing(event)
     if event.signup.closes > Time.zone.now
-      EventSignupClosingReminderWorker.perform_at(event.signup.closes - 2.hours, event.signup.id, 2.hours)
+      EventSignupClosingReminderWorker.perform_at(event.signup.closes - 12.hours, event.signup.id, 12.hours)
     end
   end
 

--- a/app/workers/event_signup_closing_reminder_worker.rb
+++ b/app/workers/event_signup_closing_reminder_worker.rb
@@ -4,7 +4,7 @@ class EventSignupClosingReminderWorker
 
   def perform(event_signup_id, time_until)
     event_signup = EventSignup.includes(:event_users).find(event_signup_id)
-    notify(event_signup) if notifyable(event_signup, time_until)
+    notify(event_signup) if notifyable(event_signup)
   end
 
   private

--- a/config/locales/models/user.sv.yml
+++ b/config/locales/models/user.sv.yml
@@ -52,5 +52,5 @@ sv:
         unconfirmed_email: Obekräftad epost
         username: Användarnamn
         notify_event_users: Push-notiser för eventanmälan
-        notify_event_closing: Push-notiser två timmar före eventanmälan stänger
+        notify_event_closing: Push-notiser före eventanmälan stänger
         notify_messages: Push-notiser för meddelanden


### PR DESCRIPTION
This PR changes and fixes a few things which was added in #813. 

Users that are not registered for an event and have turned on the event signup notification will now receive a notification 12 hours before the signup closes instead of the previously two hours before. This is due to many signup ends at midnight.