### PR TITLE
Custom message renderer

### DIFF
--- a/app/helpers/message_helper.rb
+++ b/app/helpers/message_helper.rb
@@ -1,4 +1,34 @@
+# frozen_string_literal: true
+
 module MessageHelper
+  MARKDOWN_EXTENSIONS = {
+    quote: true,
+    autolink: true,
+    underline: true,
+    lax_spacing: true,
+    no_intra_emphasis: true,
+    fenced_code_blocks: true,
+    space_after_headers: true
+  }.freeze
+
+  API_OPTIONS = { link_attributes: { class: 'external', target: '_system' } }.freeze
+
+  def self.markdown(text)
+    MarkdownHelper.sanitize(renderer.render(text)) if text.present?
+  end
+
+  def self.markdown_api(text)
+    MarkdownHelper.sanitize(api_renderer.render(text)) if text.present?
+  end
+
+  def self.renderer
+    Redcarpet::Markdown.new(MessageRenderer.new({}), MARKDOWN_EXTENSIONS)
+  end
+
+  def self.api_renderer
+    Redcarpet::Markdown.new(MessageRenderer.new(API_OPTIONS), MARKDOWN_EXTENSIONS)
+  end
+
   def message_destroy_link(message)
     link_to(admin_message_path(message),
             method: :delete,

--- a/app/models/messages/message.rb
+++ b/app/models/messages/message.rb
@@ -7,7 +7,7 @@ class Message < ApplicationRecord
   has_many :group_messages, dependent: :destroy
   has_many :groups, through: :group_messages
 
-  paginates_per(15)
+  paginates_per(30)
 
   validates :content, presence: true
   validates :groups, length: { minimum: 1, message: I18n.t('model.message.need_groups') }

--- a/app/renderers/message_renderer.rb
+++ b/app/renderers/message_renderer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MessageRenderer < Redcarpet::Render::HTML
+  DEFAULT_OPTIONS = { hard_wrap: true, escape_html: true }.freeze
+
+  def initialize(options)
+    super(DEFAULT_OPTIONS.merge(options))
+  end
+
+  def header(text, _header_level)
+    "<p># #{text}</p>"
+  end
+end

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -1,6 +1,6 @@
 class MessageSerializer < ActiveModel::Serializer
   attributes(:id, :by_admin, :updated_at)
-  attribute(:text) { MarkdownHelper.markdown_api(object.content) }
+  attribute(:text) { MessageHelper.markdown_api(object.content) }
   attribute(:day) { object.created_at.to_date }
   attribute(:time) { object.created_at.strftime('%H:%M') }
 

--- a/app/views/admin/messages/_message.html.erb
+++ b/app/views/admin/messages/_message.html.erb
@@ -15,6 +15,6 @@
         <%= localized(message.created_at, format: :short) %>
       </small>
     </div>
-    <%= markdown(message.content) %>
+    <%= MessageHelper.markdown(message.content) %>
   </div>
 </div>


### PR DESCRIPTION
Adds a new markdown renderer for messages. Disables things like headers,
tables, html tags and other strange things that one would not expect to
find in a chat.

Also loads 30 messages/page instead of 15.