### PR TITLE
Restricting group permissions

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -81,7 +81,6 @@ class Ability
       can [:destroy], Candidate, user_id: user.id
       can [:create], Nomination
       can :show, Page, visible: true
-      can [:edit, :update], Group, group_users: { fadder: true, user: user }
       can [:create, :destroy], Meeting, user_id: user.id
       can([:edit, :update], Meeting, user_id: user.id, by_admin: false,
                                      status: Meeting.statuses[:unconfirmed])

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,7 +1,0 @@
-<%= simple_form_for(group) do |f| %>
-  <%= f.association(:users, collection: User.by_firstname.confirmed,
-                            input_html: { class: 'select2' },
-                            include_blank: false,
-                            label_method: :print_program) %>
-  <%= f.button :submit %>
-<% end %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,8 +1,0 @@
-<div class="col-md-6 col-md-offset-3 col-xs-12 reg-page">
-  <div class="headline">
-    <h3><%= title(t('.title')) %></h3>
-  </div>
-  <%= render('form', group: @group) %>
-  <hr>
-  <%= link_to(t('.back'), group_path(@group), class: 'btn secondary') %>
-</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -6,12 +6,6 @@
     <%= render @group_view.group.group_users.includes(:user) %>
   <% end %>
 
-  <% if can?(:edit, @group_view.group) %>
-    <%= link_to edit_group_path(@group_view.group) do %>
-      <%= fa_icon('cog') %> <%= t('global.edit') %>
-    <% end %>
-  <% end %>
-
   <hr>
   <% if @group.introduction.present? %>
     <%= link_to(@group.introduction, introduction_path(@group_view.group.introduction),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,7 +302,7 @@ Fsek::Application.routes.draw do
       end
     end
 
-    resources :groups, path: :grupper, except: [:new, :create, :destroy] do
+    resources :groups, path: :grupper, only: [:index, :show] do
       resources :messages, only: [:index], path: :meddelanden do
         get :download_image, on: :member
       end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -27,30 +27,4 @@ RSpec.describe GroupsController, type: :controller do
       assigns(:introductions).should eq([introduction])
     end
   end
-
-  describe 'GET #edit' do
-    it 'renders sucessfully' do
-      group = create(:group)
-
-      get :edit, params: { id: group.to_param }
-      response.should have_http_status(200)
-      assigns(:group).should eq(group)
-    end
-  end
-
-  describe 'GET #update' do
-    it 'valid parameters' do
-      group = create(:group)
-      user = create(:user)
-      attributes = { user_ids: [user.id] }
-
-      user.groups.should_not include(group)
-
-      patch :update, params: { id: group.to_param, group: attributes }
-
-      user.reload
-      response.should redirect_to(group_path(group))
-      user.groups.should include(group)
-    end
-  end
 end

--- a/spec/features/groups_spec.rb
+++ b/spec/features/groups_spec.rb
@@ -26,31 +26,4 @@ RSpec.feature 'Groups' do
                                                               action: 'show',
                                                               subject: 'group'))
   end
-
-  scenario 'fadder visits #edit' do
-    user = create(:user)
-    group = create(:group, name: 'Godtycklig grupp')
-    create(:group_user, group: group, user: user, fadder: true)
-
-    sign_in_as(user)
-
-    page.visit(edit_group_path(group))
-    page.should have_text(I18n.t('groups.edit.title'))
-    page.should_not have_css('div.alert.alert-danger')
-  end
-
-  scenario 'nolla visits #edit' do
-    user = create(:user)
-    group = create(:group, name: 'Godtycklig grupp')
-    create(:group_user, group: group, user: user)
-
-    sign_in_as(user)
-
-    page.visit(edit_group_path(group))
-    page.should_not have_text(I18n.t('groups.edit.title'))
-    page.should have_css('div.alert.alert-danger')
-    find('div.alert.alert-danger').text.should include(I18n.t('unauthorized.manage.all',
-                                                              action: :edit,
-                                                              subject: 'group'))
-  end
 end


### PR DESCRIPTION
In the spirits of GDPR I restrict the mentors permissions to see the all users when editing their groups. Now only admins can edit groups.