### PR TITLE
Updated event API to support infinite scroll

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -8,6 +8,19 @@ class Api::EventsController < Api::BaseController
     render json: @events, namespace: '' # Use the same serializer as for the web calendar
   end
 
+  def scroll
+    authorize!(:scroll, :api_event)
+
+    # Loads all events for each day and atleast 7 in total
+    @events = Event.includes(:translations).after_date(params[:start]).by_start.limit(7)
+    if @events.length == 7
+      last_day = Event.includes(:translations).from_date(@events[-1].starts_at).by_start
+      @events = (@events.to_a + last_day.to_a).uniq
+    end
+
+    render json: @events, namespace: ''
+  end
+
   def show
     authorize!(:show, :api_event)
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -58,7 +58,7 @@ class Ability
       can [:index, :visit, :look, :look_all], Notification, user_id: user.id
       can [:create, :destroy], PushDevice
       can :index, :start
-      can :read, :api_event
+      can [:read, :scroll], :api_event
       can [:create, :destroy], Fredmansky
     end
 

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -3,9 +3,16 @@ class EventSerializer < ActiveModel::Serializer
   attribute(:description) { object.description || '' }
   attribute(:location)
   attribute(:allday) { object.all_day? }
+  attribute(:has_signup) { object.signup.present? }
+  attribute(:signup_not_opened_yet) { object.signup.present? && object.signup.opens > Time.zone.now }
   attribute(:recurring) { false }
   attribute(:url) { Rails.application.routes.url_helpers.event_path(object.id) }
   attribute(:textColor) { 'black' }
+  has_one :event_signup
+
+  has_one :event_user do
+    object.event_users.where(user: scope).first
+  end
 
   def start
     if object.all_day?
@@ -21,5 +28,9 @@ class EventSerializer < ActiveModel::Serializer
     else
       object.ends_at.iso8601
     end
+  end
+
+  class EventUserSerializer < ActiveModel::Serializer
+    attribute(:reserve) { object.reserve? }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -359,6 +359,7 @@ Fsek::Application.routes.draw do
     resources :versions, only: :index
 
     resources :events, only: [:index, :show] do
+      get :scroll, on: :collection
       resources :event_users, only: [:create, :destroy]
     end
 


### PR DESCRIPTION
Loads all events for each day and atleast 7 in total.

If for example the day of the 7:th event has 2 more events after, then those will be included aswell, i.e. 9 events will be loaded in total.