### PR TITLE
Embedded SoundCloud player added to start page

### DIFF
--- a/app/assets/stylesheets/partials/_ads.scss
+++ b/app/assets/stylesheets/partials/_ads.scss
@@ -56,7 +56,7 @@
     }
   }
 
-  .weektorn {
+  .weektorn, .podcast {
     margin-bottom: 20px;
   }
 

--- a/app/views/static_pages/_ads.html.erb
+++ b/app/views/static_pages/_ads.html.erb
@@ -38,6 +38,20 @@
     <% end %>
   </div>
 
+  <div class="podcast box">
+    <div class="headline">
+      <h3><%= link_to(t('.podcast'), 'https://soundcloud.com/user-165272144', :target => '_blank') %></h3>
+    </div>
+    <p>
+      <%= t('.podcast_listen') %>
+      <%= contact_from_slug(slug: 'sanningsminister') %>
+    </p>
+    <p>
+      <%= link_to(t('.podcast_soundcloud'), 'https://soundcloud.com/user-165272144', :target => '_blank') %>
+    </p>
+    <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/users/584893281&color=%23eb7125&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>
+  </div>
+
   <div class="box">
     <div class="headline">
       <h3><%= link_to(t('.contact'), contacts_path) %></h3>

--- a/config/locales/onesky_en/index_static_pages.en.yml
+++ b/config/locales/onesky_en/index_static_pages.en.yml
@@ -40,6 +40,9 @@ en:
       weektorn_send_in: "Want to submit a post to  Weektorn? Send it to"
       weektorn_subscribe: "Subscribe for the F-guilds weekly newsletter which is sent out every week of studies."
       weektorn_read_online: You can also read Weektorn here.
+      podcast: Hilbert's Corner
+      podcast_listen: Listen to the F-guild's podcast here! Questions or comments regarding the podcast can be sent to
+      podcast_soundcloud: You can also listen to Hilbert's Corner here on SoundCloud.
       contact: Contact us
       contact_info: Please contact us using
       contact_info2: this contact page,

--- a/config/locales/views/static_pages/index_static_pages.sv.yml
+++ b/config/locales/views/static_pages/index_static_pages.sv.yml
@@ -38,6 +38,9 @@ sv:
       weektorn_send_in: Vill du skicka med en notis i Vecktorn? Skicka i så fall in den till
       weektorn_subscribe: Prenumerera på F-sektionens veckobrev som kommer ut varje läsvecka!
       weektorn_read_online: Du kan också läsa Vecktorn här.
+      podcast: Hilberts Hörna
+      podcast_listen: Lyssna på F-sektionens podcast här! Frågor eller kommentarer gällande podcasten kan skickas till
+      podcast_soundcloud: Du kan också lyssna på Hilberts Hörna här på SoundCloud.
       contact: Kontakta oss
       contact_info: Kontakta oss gärna genom
       contact_info2: denna kontaktsida,


### PR DESCRIPTION
This PR adds a SoundCloud player for the podcast on the start page, see picture below. The style and position of the player can be discussed if someone has other preferences. Also, closes #901.

<img width="762" alt="skarmavbild 2019-02-08 kl 22 15 57" src="https://user-images.githubusercontent.com/26110611/52506861-356d1f00-2bf0-11e9-94ab-e6c92716ed7c.png">