### PR TITLE
Removing max-height property on notification hover

### DIFF
--- a/app/assets/stylesheets/partials/_notifications.scss
+++ b/app/assets/stylesheets/partials/_notifications.scss
@@ -138,7 +138,6 @@
 
   &:hover {
     background-color: rgba(144, 144, 144, 0.3);
-    max-height: 140px;
 
     .notification-time {
       color: $fsek-orange;


### PR DESCRIPTION
Fixes #912 