### PR TITLE
Contact avatar improvement in API

### DIFF
--- a/app/serializers/api/contacts_serializer.rb
+++ b/app/serializers/api/contacts_serializer.rb
@@ -1,12 +1,30 @@
 class Api::ContactsSerializer < ActiveModel::Serializer
-  class Api::ContactsSerializer::Show < ActiveModel::Serializer
+  include ContactHelper
+
+  class Api::ContactsSerializer::Show < Api::ContactsSerializer
     attributes(:email, :name, :text, :avatar)
     attribute(:users) { object.users.collect { |u| u.firstname + ' ' + u.lastname } }
+
+    def avatar
+      if contact_single_user(object)
+        object.users.first.avatar
+      else
+        object.avatar
+      end
+    end
   end
 
-  class Api::ContactsSerializer::Index < ActiveModel::Serializer
+  class Api::ContactsSerializer::Index < Api::ContactsSerializer
     attributes(:id, :email, :name, :text, :avatar)
     attribute(:users) { object.users.collect { |u| u.firstname + ' ' + u.lastname } }
+
+    def avatar
+      if contact_single_user(object)
+        object.users.first.avatar
+      else
+        object.avatar
+      end
+    end
 
     def text
       MarkdownHelper.markdown_api(object.text)


### PR DESCRIPTION
If contact does not have an avatar and it only has one user then the user's avatar will be used as the avatar of the contact, i.e. as it is on the website.