### PR TITLE
Event signup open notification fix

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -64,7 +64,11 @@ class NotificationService
   end
 
   def self.notify_open(event)
-    if event.signup.opens > Time.zone.now
+    if event.signup.opens <= Time.zone.now && event.event_signup.sent_open.nil?
+      # Signup on creation already open
+      EventSignupOpenReminderWorker.perform_at(Time.zone.now + 10.minutes, event.signup.id)
+    elsif event.signup.opens > Time.zone.now && event.event_signup.sent_open.nil?
+      # Signup opens sometime in the future
       EventSignupOpenReminderWorker.perform_at(event.signup.opens, event.signup.id)
     end
   end


### PR DESCRIPTION
Fixes bug where the notification was not sent if the signup on creation already was open.