### PR TITLE
Add a link to the new contact for photographers 

### DIFF
--- a/app/views/gallery/albums/show.html.erb
+++ b/app/views/gallery/albums/show.html.erb
@@ -29,7 +29,7 @@
   <% end %>
 </div>
 <br>
-<div class="col-md-3">
+<div class="col-md-2">
   <div class="headline">
     <h4><%= t('.photographers') %></h4>
   </div>
@@ -41,6 +41,7 @@
     <% @album.photographer_names.each do |p| %>
       <li><%= p.to_s %></li>
     <% end %>
+
   </ul>
   <% if @policy.present? %>
     <hr>
@@ -50,9 +51,16 @@
   <% end %>
 </div>
 
-<div class="col-md-9">
+<div class="col-md-5">
   <div class="headline">
     <h4><%= Album.human_attribute_name(:description) %></h4>
   </div>
   <%= markdown(@album.description) %>
+</div>
+
+<div class="col-md-5">
+  <div class="headline">
+    <h4>Kontakta fotograferna</h4>
+    </div>
+    <p>Har du några frågor om bilderna eller vill du ha ett event fotat? Hör av dig till <%= contact_from_slug(slug: "fotograf") %></p>
 </div>


### PR DESCRIPTION
Add a link to the new contact for photographers with a descriptive text in the albums view. This is to make it easy for users to contact the people responsible for the photos.

closes #917 