### PR TITLE
Add recurring meeting option to meetings

### DIFF
--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -12,42 +12,70 @@ class Admin::MeetingsController < Admin::BaseController
   def new
     @meeting.user = current_user
     @meeting.status = :confirmed
-    @meeting.room = params.fetch(:room, 'sk')
   end
 
   def create
-    @meeting = Meeting.new(meeting_params)
-    @meeting.by_admin = true
-    @meeting.is_admin = true
-
-    if @meeting.save
-      redirect_to edit_admin_meeting_path(@meeting), notice: alert_create(Meeting)
+    if meeting_params[:occurrences].to_i > 0
+      @first_meeting = MeetingService.create_recurring_meeting(meeting_params)
+      if !@first_meeting.nil?
+        redirect_to edit_admin_meeting_path(@first_meeting, edit_type: 'all'), notice: alert_create(RecurringMeeting)
+      else
+        render :new, status: 422
+      end
     else
-      render :new, status: 422
+      @meeting = Meeting.new(meeting_params)
+      @meeting.by_admin = true
+      @meeting.is_admin = true
+      if @meeting.save
+        redirect_to edit_admin_meeting_path(@meeting), notice: alert_create(Meeting)
+      else
+        render :new, status: 422
+      end
     end
   end
 
   def update
     @meeting = Meeting.find(params[:id])
     @meeting.is_admin = true
+    edit_type = params[:meeting][:edit_type]
 
-    if @meeting.update(meeting_params)
-      MeetingMailer.update_email(@meeting, current_user).deliver_now unless @meeting.by_admin
-      redirect_to edit_admin_meeting_path(@meeting), notice: alert_update(Meeting)
-    else
-      render :edit, status: 422
+    if edit_type == 'one'
+      if MeetingService.update_meeting(@meeting, meeting_params)
+        MeetingMailer.update_email(@meeting, current_user).deliver_now unless @meeting.by_admin
+        redirect_to edit_admin_meeting_path(@meeting), notice: alert_update(Meeting)
+      else
+        render :edit, status: 422
+      end
+    elsif edit_type == 'all'
+      @updated_meeting = MeetingService.update_all_recurring_meeting(@meeting, meeting_params)
+      if !@updated_meeting.nil?
+        redirect_to edit_admin_meeting_path(@updated_meeting, edit_type: 'all'), notice: alert_update(RecurringMeeting)
+      else
+        render :edit, status: 422
+      end
+    elsif edit_type == 'after'
+      @updated_meeting = MeetingService.update_after_recurring_meeting(@meeting, meeting_params)
+      if !@updated_meeting.nil?
+        redirect_to edit_admin_meeting_path(@updated_meeting, edit_type: 'after'), notice: alert_update(RecurringMeeting)
+      else
+        render :edit, status: 422
+      end
     end
   end
 
   def destroy
-    @meeting.destroy!
-    redirect_to admin_meetings_path, notice: alert_destroy(Meeting)
+    if MeetingService.destroy_meeting(@meeting)
+      redirect_to admin_meetings_path, notice: alert_destroy(Meeting)
+    else
+      render :edit, status: 422
+    end
   end
 
   private
 
   def meeting_params
     params.require(:meeting).permit(:start_date, :end_date, :title, :purpose, :room,
-                                    :comment, :council_id, :user_id, :status)
+                                    :comment, :council_id, :user_id, :status, :every,
+                                    :occurrences)
   end
 end

--- a/app/controllers/admin/recurring_meetings_controller.rb
+++ b/app/controllers/admin/recurring_meetings_controller.rb
@@ -1,0 +1,14 @@
+class Admin::RecurringMeetingsController < Admin::BaseController
+  load_permissions_and_authorize_resource
+
+  def destroy
+    @recurring_meeting.destroy!
+    redirect_to admin_meetings_path, notice: alert_destroy(RecurringMeeting)
+  end
+
+  private
+
+  def recurring_meeting_params
+    params.require(:recurring_meeting).permit(:every, :occurrences)
+  end
+end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -4,13 +4,17 @@ class Meeting < ApplicationRecord
 
   belongs_to :user, required: true
   belongs_to :council
+  belongs_to :recurring_meeting
 
   attr_accessor :is_admin
+  attr_accessor :every
+  attr_accessor :occurrences
 
   validates :title, presence: true
   validates :status, presence: true, inclusion: { in: ['unconfirmed'] }, unless: :is_admin
   validates :status, presence: true, inclusion: { in: statuses.keys }, if: :is_admin
   validates :room, presence: true, inclusion: { in: rooms.keys }
+
   validate :date_validation, :overlap_validation
   validate :membership_validation, :council_validation, unless: :is_admin
 

--- a/app/models/recurring_meeting.rb
+++ b/app/models/recurring_meeting.rb
@@ -1,0 +1,9 @@
+class RecurringMeeting < ApplicationRecord
+  has_many :meetings, dependent: :destroy
+
+  validates :every, presence: true, numericality: { greater_than_or_equal_to: 1 }
+
+  def occurrences
+    meetings.count
+  end
+end

--- a/app/services/meeting_service.rb
+++ b/app/services/meeting_service.rb
@@ -1,0 +1,244 @@
+module MeetingService
+  def self.create_recurring_meeting(meeting_params, old_recurring=nil)
+    occurrences = meeting_params[:occurrences].to_i
+    every = meeting_params[:every].to_i
+    start_date = Time.parse(meeting_params[:start_date])
+    end_date = Time.parse(meeting_params[:end_date])
+    meetings = Array.new(occurrences)
+
+    # Create meetings and add them to an array
+    for i in 0..occurrences - 1
+      temp_params = meeting_params
+      new_start_date = (start_date + (i * every).day).strftime('%Y-%m-%d %H:%M:%S')
+      new_end_date = (end_date + (i * every).day).strftime('%Y-%m-%d %H:%M:%S')
+      temp_params[:start_date] = new_start_date
+      temp_params[:end_date] = new_end_date
+      meeting = Meeting.new(temp_params)
+      meeting.by_admin = true
+      meeting.is_admin = true
+      meetings[i] = meeting
+    end
+
+    # Create recurring meeting and link the already created meetings to it
+    begin
+      RecurringMeeting.transaction do
+        # If old recurring is specified destroy it
+        if !old_recurring.nil?
+          old_recurring.destroy!
+        end
+        recurring_meeting = RecurringMeeting.new(every: every)
+        recurring_meeting.save!
+        meetings.each do |meeting|
+          meeting.recurring_meeting_id = recurring_meeting.id
+          meeting.save!
+        end
+      end
+      return meetings[0]
+    rescue
+      return nil
+    end
+  end
+
+  def self.update_all_recurring_meeting(meeting, meeting_params)
+    recurring_meeting = meeting.recurring_meeting
+    occurrences = meeting_params[:occurrences].to_i
+    every = meeting_params[:every].to_i
+    start_date = Time.parse(meeting_params[:start_date]).to_date
+    end_date = Time.parse(meeting_params[:end_date]).to_date
+
+    if start_date != meeting.start_date.to_date || end_date != meeting.end_date.to_date
+      # This and the meetings after will be removed from current recurring meeting and a new recurring meeting will be created
+      nbr_meetings_after = Meeting.where(recurring_meeting_id: recurring_meeting.id).from_date(meeting.start_date).length
+      meeting_params[:occurrences] = nbr_meetings_after
+
+      date_changed(meeting, meeting_params)
+    elsif every != recurring_meeting.every
+      # Remove current recurring meeting including its meetings, and create a new recurring meeting
+      meeting = Meeting.where(recurring_meeting_id: recurring_meeting.id)[0]
+      meeting_params[:start_date] = meeting.start_date.strftime('%Y-%m-%d %H:%M:%S')
+      meeting_params[:end_date] = meeting.end_date.strftime('%Y-%m-%d %H:%M:%S')
+
+      create_recurring_meeting(meeting_params, recurring_meeting)
+    else
+      if occurrences != recurring_meeting.occurrences
+        # Add or remove meetings
+        meeting = occurrences_changed(meeting, meeting_params.clone)
+        if meeting.nil?
+          return nil
+        end
+      end
+
+      # Update time and information of all meetings
+      meetings = Meeting.where(recurring_meeting_id: recurring_meeting.id)
+      update_meetings(meeting, meetings, meeting_params)
+    end
+  end
+
+  def self.update_after_recurring_meeting(meeting, meeting_params)
+    recurring_meeting = meeting.recurring_meeting
+    occurrences = meeting_params[:occurrences].to_i
+    every = meeting_params[:every].to_i
+    start_date = Time.parse(meeting_params[:start_date])
+    end_date = Time.parse(meeting_params[:end_date])
+
+    if start_date != meeting.start_date || end_date != meeting.end_date || every != recurring_meeting.every || occurrences != recurring_meeting.occurrences
+      # This meetinng and the ones after will be removed from current recurring meeting and a new recurring meeting will be created
+      if every == recurring_meeting.every && occurrences == recurring_meeting.occurrences
+        nbr_meetings_after = Meeting.where(recurring_meeting_id: recurring_meeting.id).from_date(meeting.start_date).length
+        meeting_params[:occurrences] = nbr_meetings_after
+      end
+      date_changed(meeting, meeting_params)
+    else
+      # Update time and information of this and following meetings
+      meetings_after = Meeting.where(recurring_meeting_id: recurring_meeting.id).from_date(meeting.start_date)
+      update_meetings(meeting, meetings_after, meeting_params)
+    end
+  end
+
+  def self.update_meeting(meeting, meeting_params)
+    # If it was recurring, decouple it
+    if !meeting.recurring_meeting_id.nil?
+      begin
+        RecurringMeeting.transaction do
+          recurring_meeting = meeting.recurring_meeting
+          meeting.recurring_meeting_id = nil
+          meeting.save!
+          if recurring_meeting.occurrences.zero?
+            # If this meeting was the last one, delete the recurring meeting object
+            recurring_meeting.destroy!
+          end
+        end
+      rescue
+        false
+      end
+    end
+    meeting.update(meeting_params)
+  end
+
+  def self.update_meetings(meeting, meetings, meeting_params)
+    start_date = Time.parse(meeting_params[:start_date])
+    end_date = Time.parse(meeting_params[:end_date])
+
+    # Update the time of all meetings if it has changed
+    if start_date.strftime('%H:%M:%S') != meeting.start_date.strftime('%H:%M:%S') || end_date.strftime('%H:%M:%S') != meeting.end_date.strftime('%H:%M:%S')
+      # Get time for start and end
+      start_time_hh = start_date.strftime('%H')
+      start_time_mm = start_date.strftime('%M')
+      end_time_hh = end_date.strftime('%H')
+      end_time_mm = end_date.strftime('%M')
+      begin
+        Meeting.transaction do
+          meetings.each do |m|
+            m.is_admin = true
+            new_start_date = m.start_date
+            new_end_date = m.end_date
+            m.start_date = new_start_date.change({ hour: start_time_hh, min: start_time_mm })
+            m.end_date = new_end_date.change({ hour: end_time_hh, min: end_time_mm })
+            m.save!
+          end
+        end
+      rescue
+        return nil
+      end
+    end
+
+    # Update only meeting information
+    meeting_params.delete('start_date')
+    meeting_params.delete('end_date')
+    begin
+      Meeting.transaction do
+        meetings.each do |m|
+          m.is_admin = true
+          m.update!(meeting_params)
+        end
+        meeting
+      end
+    rescue
+      nil
+    end
+  end
+
+  def self.date_changed(meeting, meeting_params)
+    meetings_after = Meeting.where(recurring_meeting_id: meeting.recurring_meeting_id).from_date(meeting.start_date)
+    begin
+      Meeting.transaction do
+        meetings_after.each do |m|
+          m.destroy!
+        end
+        create_recurring_meeting(meeting_params)
+      end
+    rescue
+      nil
+    end
+  end
+
+  def self.occurrences_changed(meeting, meeting_params)
+    recurring_meeting = meeting.recurring_meeting
+    occurrences = meeting_params[:occurrences].to_i
+    meetings = Meeting.where(recurring_meeting_id: recurring_meeting.id)
+
+    diff = meetings.length - occurrences
+    if diff.positive?
+      # Delete meetings from recurring meeting
+      begin
+        Meeting.transaction do
+          meetings[occurrences..-1].each do |m|
+            m.destroy!
+          end
+        end
+      rescue
+        return nil
+      end
+      meetings[occurrences - 1]
+    else
+      # Add meetings to recurring meeting
+      every = meeting_params[:every].to_i
+      start_date = meetings[-1].start_date
+      end_date = meetings[-1].end_date
+      new_meetings = Array.new(diff.abs)
+      for i in 1..diff.abs
+        temp_params = meeting_params
+        new_start_date = (start_date + (i * every).day).strftime('%Y-%m-%d %H:%M:%S')
+        new_end_date = (end_date + (i * every).day).strftime('%Y-%m-%d %H:%M:%S')
+        temp_params[:start_date] = new_start_date
+        temp_params[:end_date] = new_end_date
+        m = Meeting.new(temp_params)
+        m.by_admin = true
+        m.is_admin = true
+        new_meetings[i - 1] = m
+      end
+
+      begin
+        Meeting.transaction do
+          new_meetings.each do |m|
+            m.recurring_meeting_id = recurring_meeting.id
+            m.save!
+          end
+        end
+      rescue
+        return nil
+      end
+      meeting
+    end
+  end
+
+  def self.destroy_meeting(meeting)
+    if !meeting.recurring_meeting_id.nil?
+      recurring_meeting = meeting.recurring_meeting
+      begin
+        if recurring_meeting.occurrences > 1
+          # If it was recurring we need to update the number of occurrences
+          meeting.destroy!
+        elsif recurring_meeting.occurrences == 1
+          # If it was the last one we can simply delete the recurring meeting object
+          recurring_meeting.destroy!
+        end
+        true
+      rescue
+        false
+      end
+    else
+      meeting.destroy
+    end
+  end
+end

--- a/app/views/admin/meetings/_form.html.erb
+++ b/app/views/admin/meetings/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render 'overlap', meeting: meeting %>
 
-<%= simple_form_for([:admin, meeting]) do |f| %>
+<%= simple_form_for([:admin, meeting], html: {id: "meeting_form"}) do |f| %>
   <%= f.association :user, collection: User.members, include_blank: false, input_html: {class: 'select2'} %>
   <%= f.input :title %>
 
@@ -16,5 +16,24 @@
 
   <%= f.input :comment, placeholder: t('.denied_comment') %>
 
+  <hr>
+
+  <% if form_type == 'new' %>
+    <h4><%= t('.repeat_description') %></h4>
+    <%= f.input :every, as: :integer, placeholder: t('.every_comment'), required: false, default: 0, input_html: { min: 1 } %>
+    <%= f.input :occurrences, as: :integer, required: false, default: 1, input_html: { min: 1 } %>
+  <% elsif form_type == 'edit_one' %>
+    <%= f.hidden_field :edit_type, value: 'one' %>
+  <% elsif form_type == 'edit_all' || form_type == 'edit_after' %>
+    <% if form_type == 'edit_all' %>
+      <%= f.hidden_field :edit_type, value: 'all' %>
+    <% else %>
+      <%= f.hidden_field :edit_type, value: 'after' %>
+    <% end %>
+    <%= f.input :every, as: :integer, required: false, input_html: { min: 1, value: meeting.recurring_meeting.every } %>
+    <%= f.input :occurrences, as: :integer, required: false, input_html: { min: 1, value: meeting.recurring_meeting.occurrences } %>
+  <% end %>
+
   <%= f.button :submit %>
+
 <% end %>

--- a/app/views/admin/meetings/_meeting.html.erb
+++ b/app/views/admin/meetings/_meeting.html.erb
@@ -53,6 +53,16 @@
           <td><%= simple_format(meeting.purpose) %></td>
         </tr>
       <% end %>
+      <% if !meeting.recurring_meeting_id.nil? %>
+        <tr>
+          <td><%= Meeting.human_attribute_name(:every) %></td>
+          <td><%= simple_format(meeting.recurring_meeting.every.to_s) %></td>
+        </tr>
+        <tr>
+          <td><%= Meeting.human_attribute_name(:occurrences) %></td>
+          <td><%= simple_format(meeting.recurring_meeting.occurrences.to_s) %></td>
+        </tr>
+      <% end %>
     </tbody>
   </table>
 </div>

--- a/app/views/admin/meetings/edit.html.erb
+++ b/app/views/admin/meetings/edit.html.erb
@@ -3,7 +3,14 @@
     <h1><%= title(t('.title')) %></h1>
   </div>
 
-  <%= render 'form', meeting: @meeting %>
+  <% if params[:edit_type] == 'all' %>
+    <%= render 'form', meeting: @meeting, form_type: 'edit_all' %>
+  <% elsif params[:edit_type] == 'after' %>
+    <%= render 'form', meeting: @meeting, form_type: 'edit_after' %>
+  <% else %>
+    <%= render 'form', meeting: @meeting, form_type: 'edit_one' %>
+  <% end %>
+
   <hr>
   <%= link_to(t('.destroy'), admin_meeting_path(@meeting),
                                  method: :delete,

--- a/app/views/admin/meetings/new.html.erb
+++ b/app/views/admin/meetings/new.html.erb
@@ -3,7 +3,7 @@
     <h1><%= title(t('.title')) %></h1>
   </div>
 
-  <%= render 'form', meeting: @meeting %>
+  <%= render 'form', meeting: @meeting, form_type: 'new' %>
 
   <hr>
   <%= link_to(t('.administrate'), admin_meetings_path, class: 'btn secondary') %>

--- a/app/views/admin/meetings/show.html.erb
+++ b/app/views/admin/meetings/show.html.erb
@@ -2,12 +2,24 @@
 <div class="col-md-8 col-md-offset-2 col-xs-12 reg-page">
   <%= render @meeting %>
 
-  <%= link_to(t('.edit'), edit_admin_meeting_path(@meeting), class: 'btn primary') %>
+  <%= link_to(t('.edit'), edit_admin_meeting_path(@meeting, edit_type: 'one'), class: 'btn primary') %>
+
+  <% if !@meeting.recurring_meeting_id.nil? %>
+    <%= link_to(t('.edit_all'), edit_admin_meeting_path(@meeting, edit_type: 'all'), class: 'btn primary') %>
+    <%= link_to(t('.edit_after'), edit_admin_meeting_path(@meeting, edit_type: 'after'), class: 'btn primary') %>
+  <% end %>
 
   <%= link_to(t('.index'), admin_meetings_path, class: 'btn secondary') %>
-
+  <br>
   <%= link_to(t('.destroy'), admin_meeting_path(@meeting),
                              method: :delete,
                              data: {confirm: t('.confirm_destroy')},
                              class: 'btn danger pull-right') %>
+
+  <% if !@meeting.recurring_meeting_id.nil? %>
+      <%= link_to(t('.destroy_all'), admin_recurring_meeting_path(@meeting.recurring_meeting),
+                                 method: :delete,
+                                 data: {confirm: t('.confirm_destroy_all')},
+                                 class: 'btn danger pull-right') %>
+  <% end %>
 </div>

--- a/config/locales/models/meeting.sv.yml
+++ b/config/locales/models/meeting.sv.yml
@@ -32,3 +32,5 @@ sv:
         unconfirmed: Obekräftad
         denied: Nekad
         comment: Kommentar
+        every: Var (dag)
+        occurrences: Förekomster

--- a/config/locales/models/recurring_meeting.sv.yml
+++ b/config/locales/models/recurring_meeting.sv.yml
@@ -1,0 +1,10 @@
+sv:
+  activerecord:
+    models:
+      recurring_meeting:
+        one: Upprepande lokalbokning
+        other: Upprepande lokalbokningar
+    attributes:
+      recurring_meeting:
+        every: Var (dag)
+        occurrences: Förekomster

--- a/config/locales/views/admin/meetings/meetings_admin.sv.yml
+++ b/config/locales/views/admin/meetings/meetings_admin.sv.yml
@@ -3,6 +3,8 @@ sv:
     meetings:
       form:
         denied_comment: Kommentar vid nekad bokning
+        repeat_description: Redigera endast fälten nedan om du vill upprepa bokningen
+        every_comment: Antal dagar mellan bokningarna
 
       index:
         title: Administrera lokalbokningar
@@ -22,8 +24,12 @@ sv:
       show:
         title: Administrera lokalbokningar
         edit: Redigera bokning
+        edit_all: Redigera alla bokningar
+        edit_after: Redigera denna och kommande bokningar
         confirm_destroy: Är du säker på att du vill förinta bokningen?
+        confirm_destroy_all: Är du säker på att du vill förinta alla bokningar?
         destroy: Förinta bokning
+        destroy_all: Förinta alla bokningar
         index: Alla bokningar
 
       overlap:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Fsek::Application.routes.draw do
 
       resources :car_bans, path: :bilsparr, except: :show
       resources :achievements, path: :prestationer
+      resources :recurring_meetings, path: :upprepandelokalbokningar, only: :destroy
     end
 
     resources :rents, path: :bilbokning do

--- a/db/migrate/20180512180902_add_closing_user_notification_settings.rb
+++ b/db/migrate/20180512180902_add_closing_user_notification_settings.rb
@@ -1,0 +1,5 @@
+class AddClosingUserNotificationSettings < ActiveRecord::Migration[5.0]
+  def change
+    add_column(:users, :notify_event_closing, :boolean, null: false, default: false)
+  end
+end

--- a/db/migrate/20180513125456_add_closing_add_reminder_dates_to_event_signup.rb
+++ b/db/migrate/20180513125456_add_closing_add_reminder_dates_to_event_signup.rb
@@ -1,0 +1,5 @@
+class AddClosingAddReminderDatesToEventSignup < ActiveRecord::Migration[5.0]
+  def change
+    add_column(:event_signups, :sent_closing, :datetime)
+  end
+end

--- a/db/migrate/20190410191800_add_recurring_meetings.rb
+++ b/db/migrate/20190410191800_add_recurring_meetings.rb
@@ -1,0 +1,7 @@
+class AddRecurringMeetings < ActiveRecord::Migration[5.0]
+  def change
+    create_table :recurring_meetings do |t|
+      t.integer :recurring_meetings, :every, default: 0, null: false
+    end
+  end
+end

--- a/db/migrate/20190410192700_add_recurring_meetings_to_meetings.rb
+++ b/db/migrate/20190410192700_add_recurring_meetings_to_meetings.rb
@@ -1,0 +1,5 @@
+class AddRecurringMeetingsToMeetings < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :meetings, :recurring_meeting, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190302120500) do
+ActiveRecord::Schema.define(version: 20190410192700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -216,7 +216,7 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.index ["category_id"], name: "index_categorizations_on_category_id"
   end
 
-  create_table "category_translations", id: :serial, force: :cascade do |t|
+  create_table "category_translations", force: :cascade do |t|
     t.integer "category_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", null: false
@@ -258,7 +258,7 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.index ["slug"], name: "index_contacts_on_slug"
   end
 
-  create_table "council_translations", id: :serial, force: :cascade do |t|
+  create_table "council_translations", force: :cascade do |t|
     t.integer "council_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", null: false
@@ -310,7 +310,7 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.index ["post_id"], name: "index_election_posts_on_post_id"
   end
 
-  create_table "election_translations", id: :serial, force: :cascade do |t|
+  create_table "election_translations", force: :cascade do |t|
     t.integer "election_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", null: false
@@ -430,6 +430,7 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.integer "price"
     t.string "dress_code", limit: 255
     t.integer "contact_id"
+    t.index ["contact_id"], name: "index_events_on_contact_id"
   end
 
   create_table "faqs", id: :serial, force: :cascade do |t|
@@ -567,8 +568,10 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.boolean "by_admin", default: false, null: false
     t.integer "status", default: 0
     t.integer "room", default: 0
+    t.integer "recurring_meeting_id"
     t.index ["council_id"], name: "index_meetings_on_council_id"
     t.index ["end_date"], name: "index_meetings_on_end_date"
+    t.index ["recurring_meeting_id"], name: "index_meetings_on_recurring_meeting_id"
     t.index ["start_date"], name: "index_meetings_on_start_date"
     t.index ["user_id"], name: "index_meetings_on_user_id"
   end
@@ -744,7 +747,7 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "post_translations", id: :serial, force: :cascade do |t|
+  create_table "post_translations", force: :cascade do |t|
     t.integer "post_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", null: false
@@ -782,6 +785,11 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.index ["user_id"], name: "index_push_devices_on_user_id"
   end
 
+  create_table "recurring_meetings", id: :serial, force: :cascade do |t|
+    t.integer "recurring_meetings", default: 0, null: false
+    t.integer "every", default: 0, null: false
+  end
+
   create_table "rents", id: :serial, force: :cascade do |t|
     t.datetime "d_from"
     t.datetime "d_til"
@@ -798,7 +806,7 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.index ["user_id"], name: "index_rents_on_user_id"
   end
 
-  create_table "rpush_apps", id: :serial, force: :cascade do |t|
+  create_table "rpush_apps", force: :cascade do |t|
     t.string "name", null: false
     t.string "environment"
     t.text "certificate"
@@ -814,7 +822,7 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.datetime "access_token_expiration"
   end
 
-  create_table "rpush_feedback", id: :serial, force: :cascade do |t|
+  create_table "rpush_feedback", force: :cascade do |t|
     t.string "device_token", limit: 64, null: false
     t.datetime "failed_at", null: false
     t.datetime "created_at", null: false
@@ -823,7 +831,7 @@ ActiveRecord::Schema.define(version: 20190302120500) do
     t.index ["device_token"], name: "index_rpush_feedback_on_device_token"
   end
 
-  create_table "rpush_notifications", id: :serial, force: :cascade do |t|
+  create_table "rpush_notifications", force: :cascade do |t|
     t.integer "badge"
     t.string "device_token", limit: 64
     t.string "sound"
@@ -987,6 +995,7 @@ ActiveRecord::Schema.define(version: 20190302120500) do
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
   add_foreign_key "meetings", "councils"
+  add_foreign_key "meetings", "recurring_meetings"
   add_foreign_key "meetings", "users"
   add_foreign_key "menus", "main_menus"
   add_foreign_key "messages", "users"


### PR DESCRIPTION
This PR adds the long awaited feature to repeat meetings. Also, closes #921.

When creating a new meeting using the admin form (only admins can create recurring meetings), the user can now set how many days there should be between each meeting and also how many times it should occur.

Once a recurring meeting has been created, one may choose to edit the selected meeting, the selected and the meetings after or all meetings. The way a `Meeting` is connected to its `RecurringMeeting` when edited is furthermore based on Google calendar's implementation of recurring events.