### PR TITLE
Adding the possibility to lock or unlock adventure missions in a specific adventure

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,5 +49,8 @@ Metrics/LineLength:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-  Style/FrozenStringLiteralComment:
-    EnforcedStyle: never
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Style/AndOr:
+  EnforcedStyle: conditionals

--- a/app/controllers/admin/adventure_mission_groups_controller.rb
+++ b/app/controllers/admin/adventure_mission_groups_controller.rb
@@ -8,22 +8,28 @@ class Admin::AdventureMissionGroupsController < Admin::BaseController
   end
 
   def edit
-    @group = Group.find(params[:group_id])
+    @group = @adventure_mission_group.group
   end
 
   def update
-    if @adventure_mission_group.update!(adventure_mission_group_params)
-      redirect_to admin_group_adventures_path(group: @group), notice: t('.success')
+    # No validation here since there are admins doing this
+    @adventure_mission_group.points = adventure_mission_group_params[:points]
+    if @adventure_mission_group.save(validate: false)
+      redirect_to admin_group_adventures_path(group_id: @adventure_mission_group.group.id),
+                  notice: alert_success(t('.success'))
     else
-      render :edit, alert: t('.failed')
+      redirect_to edit_admin_adventure_mission_group_path(group: @group),
+                  alert: alert_errors(@adventure_mission_group.errors.full_messages)
     end
   end
 
   def destroy
-    if @adventure_mission_group.destroy!
-      redirect_to admin_group_adventures_path(group: @group), notice: t('.success')
+    group = @adventure_mission_group.group
+    if @adventure_mission_group.delete
+      redirect_to admin_group_adventures_path(group_id: group.id), notice: alert_success(t('.success'))
     else
-      render :edit, alert: t('.failed')
+      redirect_to edit_admin_adventure_mission_group_path(group: @group),
+                  alert: alert_errors(@adventure_mission_group.errors.full_messages)
     end
   end
 

--- a/app/controllers/admin/adventure_missions_controller.rb
+++ b/app/controllers/admin/adventure_missions_controller.rb
@@ -14,35 +14,34 @@ class Admin::AdventureMissionsController < Admin::BaseController
 
   def create
     @adventure_mission = AdventureMission.new(adventure_mission_params)
-
-    AdventureMissionService.shift_index_on_create(@adventure, adventure_mission_params[:index].to_i)
-
     @adventure_mission.adventure = @adventure
 
     if @adventure_mission.save!
-      redirect_to admin_adventure_adventure_missions_path(@adventure), notice: alert_create(Adventure)
+      AdventureMissionService.shift_index_on_create(@adventure, adventure_mission_params[:index].to_i)
+      redirect_to admin_adventure_adventure_missions_path(@adventure), notice: alert_create(AdventureMission)
     else
       render :new, status: 422
     end
   end
 
   def update
-    AdventureMissionService.shift_index_on_update(@adventure, @adventure_mission.index, adventure_mission_params[:index].to_i)
-
     if @adventure_mission.update(adventure_mission_params)
-      redirect_to(admin_adventure_adventure_missions_path(@adventure), notice: alert_update(Adventure))
+      AdventureMissionService.shift_index_on_update(@adventure,
+                                                    @adventure_mission.index,
+                                                    adventure_mission_params[:index].to_i)
+      redirect_to admin_adventure_adventure_missions_path(@adventure), notice: alert_update(AdventureMission)
     else
       render :edit, status: 422
     end
   end
 
   def destroy
-    AdventureMissionService.shift_index_on_destroy(@adventure, @adventure_mission.index.to_i)
-
-    if @adventure_mission.destroy!
-      redirect_to(admin_adventure_adventure_missions_path(@adventure), notice: alert_destroy(Adventure))
+    if @adventure_mission.destroy
+      AdventureMissionService.shift_index_on_destroy(@adventure, @adventure_mission.index.to_i)
+      redirect_to admin_adventure_adventure_missions_path(@adventure), notice: alert_destroy(AdventureMission)
     else
-      render :edit, status: 422
+      redirect_to edit_admin_adventure_adventure_mission_path(@adventure, @adventure_mission),
+                  alert: alert_errors(@adventure_mission.errors.full_messages)
     end
   end
 

--- a/app/controllers/admin/adventure_missions_controller.rb
+++ b/app/controllers/admin/adventure_missions_controller.rb
@@ -53,6 +53,8 @@ class Admin::AdventureMissionsController < Admin::BaseController
   private
 
   def adventure_mission_params
-    params.require(:adventure_mission).permit(:title_sv, :title_en, :description_sv, :description_en, :max_points, :variable_points, :index)
+    params.require(:adventure_mission).permit(:title_sv, :title_en, :description_sv,
+                                              :description_en, :max_points, :variable_points,
+                                              :index, :locked)
   end
 end

--- a/app/controllers/admin/adventures_controller.rb
+++ b/app/controllers/admin/adventures_controller.rb
@@ -9,7 +9,6 @@ class Admin::AdventuresController < Admin::BaseController
   end
 
   def create
-
     if @adventure.save
       redirect_to admin_adventures_path, notice: alert_create(Adventure)
     else
@@ -24,31 +23,36 @@ class Admin::AdventuresController < Admin::BaseController
     if @adventure.update(adventure_params)
       redirect_to(admin_adventures_path, notice: alert_update(Adventure))
     else
-      render :edit, status: 422
+      redirect_to edit_admin_adventure_path(@adventure),
+                  alert: alert_errors(@adventure.errors.full_messages)
     end
   end
 
   def lock
     @adventure = Adventure.find(params[:adventure_id])
     if @adventure.adventure_missions.update_all(locked: true)
-      redirect_to admin_adventure_adventure_missions_path, notice: { text: t('.success'), type: 'success' }
+      redirect_to admin_adventure_adventure_missions_path, notice: alert_success(t('.success'))
     else
-      redirect_to admin_adventure_adventure_missions_path, notice: { text: t('.failed'), type: 'danger' }
+      redirect_to admin_adventure_adventure_missions_path, alert: alert_danger(t('.fail'))
     end
   end
 
   def unlock
     @adventure = Adventure.find(params[:adventure_id])
     if @adventure.adventure_missions.update_all(locked: false)
-      redirect_to admin_adventure_adventure_missions_path, notice: { text: t('.success'), type: 'success' }
+      redirect_to admin_adventure_adventure_missions_path, notice: alert_success(t('.success'))
     else
-      redirect_to admin_adventure_adventure_missions_path, notice: { text: t('.failed'), type: 'danger' }
+      redirect_to admin_adventure_adventure_missions_path, notice: alert_danger(t('.fail'))
     end
   end
 
   def destroy
-    @adventure.destroy!
-    redirect_to(admin_adventures_path, notice: alert_destroy(Adventure))
+    if @adventure.destroy
+      redirect_to(admin_adventures_path, notice: alert_destroy(Adventure))
+    else
+      redirect_to edit_admin_adventure_path(@adventure),
+                  alert: alert_errors(@adventure.errors.full_messages)
+    end
   end
 
   private

--- a/app/controllers/admin/adventures_controller.rb
+++ b/app/controllers/admin/adventures_controller.rb
@@ -28,6 +28,24 @@ class Admin::AdventuresController < Admin::BaseController
     end
   end
 
+  def lock
+    @adventure = Adventure.find(params[:adventure_id])
+    if @adventure.adventure_missions.update_all(locked: true)
+      redirect_to admin_adventure_adventure_missions_path, notice: { text: t('.success'), type: 'success' }
+    else
+      redirect_to admin_adventure_adventure_missions_path, notice: { text: t('.failed'), type: 'danger' }
+    end
+  end
+
+  def unlock
+    @adventure = Adventure.find(params[:adventure_id])
+    if @adventure.adventure_missions.update_all(locked: false)
+      redirect_to admin_adventure_adventure_missions_path, notice: { text: t('.success'), type: 'success' }
+    else
+      redirect_to admin_adventure_adventure_missions_path, notice: { text: t('.failed'), type: 'danger' }
+    end
+  end
+
   def destroy
     @adventure.destroy!
     redirect_to(admin_adventures_path, notice: alert_destroy(Adventure))

--- a/app/controllers/adventure_mission_groups_controller.rb
+++ b/app/controllers/adventure_mission_groups_controller.rb
@@ -11,7 +11,9 @@ class AdventureMissionGroupsController < ApplicationController
     @adventure_mission_group.group = @group
     @adventure_mission = AdventureMission.find(adventure_mission_group_params[:adventure_mission_id])
 
-    if @adventure_mission_group.save
+    if @adventure_mission.locked?
+      render :new, status: 422, notice: t('.locked')
+    elsif @adventure_mission_group.save
       redirect_to adventure_adventure_mission_path(@adventure_mission.adventure, @adventure_mission), notice: t('.success')
     else
       render :new, status: 422, notice: t('.fail')
@@ -24,7 +26,9 @@ class AdventureMissionGroupsController < ApplicationController
 
   def update
     @adventure_mission = AdventureMission.find(adventure_mission_group_params[:adventure_mission_id])
-    if @adventure_mission_group.update(adventure_mission_group_params)
+    if @adventure_mission.locked?
+      render :edit, status: 422, notice: t('.locked')
+    elsif @adventure_mission_group.update(adventure_mission_group_params)
       redirect_to adventure_adventure_mission_path(@adventure_mission.adventure, @adventure_mission), notice:  t('.success')
     else
       render :edit, status: 422, notice: t('.fail')
@@ -33,7 +37,10 @@ class AdventureMissionGroupsController < ApplicationController
 
   def destroy
     @adventure_mission = AdventureMission.find(params[:adventure_mission])
-    if @adventure_mission_group.destroy
+
+    if @adventure_mission.locked?
+      render :edit, status: 422, notice: t('.locked')
+    elsif @adventure_mission_group.destroy
       redirect_to adventure_adventure_mission_path(@adventure_mission.adventure, @adventure_mission), notice:  t('.success')
     else
       redirect_to adventure_mission_path(@adventure_mission), notice: t('.fail')

--- a/app/controllers/adventure_mission_groups_controller.rb
+++ b/app/controllers/adventure_mission_groups_controller.rb
@@ -11,12 +11,11 @@ class AdventureMissionGroupsController < ApplicationController
     @adventure_mission_group.group = @group
     @adventure_mission = AdventureMission.find(adventure_mission_group_params[:adventure_mission_id])
 
-    if @adventure_mission.locked?
-      render :new, status: 422, notice: t('.locked')
-    elsif @adventure_mission_group.save
-      redirect_to adventure_adventure_mission_path(@adventure_mission.adventure, @adventure_mission), notice: t('.success')
+    if @adventure_mission_group.save
+      redirect_to adventure_mission_path(@adventure_mission), notice: alert_success(t('.success'))
     else
-      render :new, status: 422, notice: t('.fail')
+      redirect_to new_adventure_mission_group_path(adventure_mission: @adventure_mission),
+                  alert: alert_errors(@adventure_mission_group.errors.full_messages)
     end
   end
 
@@ -26,24 +25,22 @@ class AdventureMissionGroupsController < ApplicationController
 
   def update
     @adventure_mission = AdventureMission.find(adventure_mission_group_params[:adventure_mission_id])
-    if @adventure_mission.locked?
-      render :edit, status: 422, notice: t('.locked')
-    elsif @adventure_mission_group.update(adventure_mission_group_params)
-      redirect_to adventure_adventure_mission_path(@adventure_mission.adventure, @adventure_mission), notice:  t('.success')
+    if @adventure_mission_group.update(adventure_mission_group_params)
+      redirect_to adventure_mission_path(@adventure_mission), notice: alert_success(t('.success'))
     else
-      render :edit, status: 422, notice: t('.fail')
+      redirect_to edit_adventure_mission_group_path(@adventure_mission_group),
+                  alert: alert_errors(@adventure_mission_group.errors.full_messages)
     end
   end
 
   def destroy
-    @adventure_mission = AdventureMission.find(params[:adventure_mission])
+    @adventure_mission = @adventure_mission_group.adventure_mission
 
-    if @adventure_mission.locked?
-      render :edit, status: 422, notice: t('.locked')
-    elsif @adventure_mission_group.destroy
-      redirect_to adventure_adventure_mission_path(@adventure_mission.adventure, @adventure_mission), notice:  t('.success')
+    if @adventure_mission_group.destroy
+      redirect_to adventure_mission_path(@adventure_mission), notice: alert_danger(t('.success'))
     else
-      redirect_to adventure_mission_path(@adventure_mission), notice: t('.fail')
+      redirect_to adventure_mission_path(@adventure_mission),
+                  alert: alert_errors(@adventure_mission_group.errors.full_messages)
     end
   end
 
@@ -52,5 +49,4 @@ class AdventureMissionGroupsController < ApplicationController
   def adventure_mission_group_params
     params.require(:adventure_mission_group).permit(:points, :adventure_mission_id)
   end
-
 end

--- a/app/controllers/adventure_missions_controller.rb
+++ b/app/controllers/adventure_missions_controller.rb
@@ -1,7 +1,5 @@
 class AdventureMissionsController < ApplicationController
-  before_action :load_permissions
-  load_and_authorize_resource :adventure
-  load_and_authorize_resource :adventure_mission, through: :adventure
+  load_permissions_and_authorize_resource
 
   def show
     @group = current_user.groups.regular.last

--- a/app/controllers/api/adventure_missions_controller.rb
+++ b/app/controllers/api/adventure_missions_controller.rb
@@ -2,11 +2,6 @@ class Api::AdventureMissionsController < Api::BaseController
   load_permissions_and_authorize_resource
   rescue_from ActiveRecord::RecordNotUnique, with: :notify_not_unique
 
-  def show
-    @adventure_mission = AdventureMission.find(params[:id])
-    render json: @adventure_mission, serializer: Api::AdventureSerializer::Show
-  end
-
   def finish_adventure_mission
     adventure_mission = AdventureMission.find(params[:adventure_mission_id])
 
@@ -17,9 +12,10 @@ class Api::AdventureMissionsController < Api::BaseController
     if adventure_mission.locked?
       render json: { error: 'Too late, the mission is locked..' }, status: 422 and return
     elsif points > adventure_mission.max_points
-      render json: { error: "You can't get more than max points which is: #{adventure_mission.max_points}"}, status: 422 and return
-    elsif points == 0
-      render json: { error: 'You can\'t get 0 points'}, status: 422 and return
+      render json: { error: "You can't get more than max points which is: #{adventure_mission.max_points}" },
+             status: 422 and return
+    elsif points.zero?
+      render json: { error: 'You can\'t get 0 points' }, status: 422 and return
     end
 
     # Doing both server and database auth to stop as soon as possible
@@ -29,9 +25,9 @@ class Api::AdventureMissionsController < Api::BaseController
 
     # <finished> here is currently serving the exact same purpose as <created_at>
     adventure_mission_group = AdventureMissionGroup.new(adventure_mission: adventure_mission,
-                                                         group: group,
-                                                         points: points,
-                                                         finished: Time.now)
+                                                        group: group,
+                                                        points: points,
+                                                        finished: Time.now)
 
     if adventure_mission_group.save
       render json: :ok, status: 200

--- a/app/controllers/concerns/alerts.rb
+++ b/app/controllers/concerns/alerts.rb
@@ -7,14 +7,29 @@ module Alerts
   end
 
   def alert_update(resource)
-    %(#{model_name(resource)} #{I18n.t('global_controller.success_update')}.)
+    { text: %(#{model_name(resource)} #{I18n.t('global_controller.success_update')}.),
+      type: 'success' }
   end
 
   def alert_create(resource)
-    %(#{model_name(resource)} #{I18n.t('global_controller.success_create')}.)
+    { text: %(#{model_name(resource)} #{I18n.t('global_controller.success_create')}.),
+      type: 'success' }
   end
 
   def alert_destroy(resource)
-    %(#{model_name(resource)} #{I18n.t('global_controller.success_destroy')}.)
+    { text: %(#{model_name(resource)} #{I18n.t('global_controller.success_destroy')}.),
+      type: 'danger' }
+  end
+
+  def alert_errors(errors)
+    { errors: errors, type: 'errors' }
+  end
+
+  def alert_success(message)
+    { text: message, type: 'success' }
+  end
+
+  def alert_danger(message)
+    { text: message, type: 'danger' }
   end
 end

--- a/app/models/adventures/adventure.rb
+++ b/app/models/adventures/adventure.rb
@@ -1,15 +1,15 @@
 class Adventure < ApplicationRecord
   acts_as_paranoid
 
-  translates(:title, :content)
-  globalize_accessors(locales: [:en, :sv], attributes: [:title, :content])
-
   belongs_to :introduction, required: true
 
-  has_many :adventure_missions, dependent: :destroy, inverse_of: :adventure
+  has_many :adventure_missions, dependent: :restrict_with_error, inverse_of: :adventure
   has_many :adventure_mission_groups, through: :adventure_missions
 
   accepts_nested_attributes_for :adventure_missions, reject_if: :all_blank, allow_destroy: true
+
+  translates :title, :content
+  globalize_accessors locales: [:en, :sv], attributes: [:title, :content]
 
   validates :title_sv, :start_date, :end_date, :introduction_id, presence: true
 
@@ -24,7 +24,7 @@ class Adventure < ApplicationRecord
 
   def week_number
     # Just making sure the dates don't extend into another week
-    (end_date-3.days).strftime("%U").to_i
+    (end_date - 3.days).strftime('%U').to_i
   end
 
   def self.can_show?(user)

--- a/app/models/adventures/adventure_mission.rb
+++ b/app/models/adventures/adventure_mission.rb
@@ -1,6 +1,6 @@
 class AdventureMission < ApplicationRecord
   belongs_to :adventure, required: true
-  has_many :adventure_mission_groups, dependent: :destroy
+  has_many :adventure_mission_groups, dependent: :restrict_with_error
   has_many :groups, through: :adventure_mission_groups
 
   translates :title, :description

--- a/app/models/adventures/adventure_mission_group.rb
+++ b/app/models/adventures/adventure_mission_group.rb
@@ -2,15 +2,23 @@ class AdventureMissionGroup < ApplicationRecord
   belongs_to :adventure_mission
   belongs_to :group
 
-  #validates :points, presence: true, numericality: { greater_than: 0 }
+  before_destroy :not_locked
 
-  validate :point_validity
+  validate :point_validity, :not_locked
 
   scope :by_group, ->(group) { where(group: group) }
 
   def point_validity
     unless points.present? && points > 0 && points <= adventure_mission.max_points
       errors.add(:points, I18n.t('model.adventure_mission_group.invalid_points', max_points: adventure_mission.max_points))
+      throw :abort
+    end
+  end
+
+  def not_locked
+    if adventure_mission.locked?
+      errors.add(:locked, I18n.t('model.adventure_mission_group.locked'))
+      throw :abort
     end
   end
 end

--- a/app/serializers/api/adventure_mission_serializer.rb
+++ b/app/serializers/api/adventure_mission_serializer.rb
@@ -1,6 +1,6 @@
 class Api::AdventureMissionSerializer < ActiveModel::Serializer
   class Api::AdventureMissionSerializer::Index < ActiveModel::Serializer
-    attributes :id, :title, :max_points, :index, :variable_points
+    attributes :id, :title, :max_points, :index, :variable_points, :locked
     attribute :finished, key: :is_finished
 
     def finished
@@ -10,6 +10,6 @@ class Api::AdventureMissionSerializer < ActiveModel::Serializer
   end
 
   class Api::AdventureMissionSerializer::Show < ActiveModel::Serializer
-    attributes :id, :title, :description, :max_points, :index
+    attributes :id, :title, :description, :max_points, :index, :locked
   end
 end

--- a/app/serializers/api/adventure_mission_serializer.rb
+++ b/app/serializers/api/adventure_mission_serializer.rb
@@ -8,8 +8,4 @@ class Api::AdventureMissionSerializer < ActiveModel::Serializer
       object.finished?(@group)
     end
   end
-
-  class Api::AdventureMissionSerializer::Show < ActiveModel::Serializer
-    attributes :id, :title, :description, :max_points, :index, :locked
-  end
 end

--- a/app/views/admin/adventure_mission_groups/edit.html.erb
+++ b/app/views/admin/adventure_mission_groups/edit.html.erb
@@ -9,12 +9,12 @@
           <%= AdventureMission.human_attribute_name(:max_points) %>
         </li>
         <li class="list-group-item">
-          <%= simple_form_for([:admin, @group, @adventure_mission_group]) do |f| %>
+          <%= simple_form_for([:admin, @adventure_mission_group]) do |f| %>
             <%= f.input :points %>
             <%= f.input :adventure_mission_id, as: :hidden, input_html: { value: @adventure_mission_group.adventure_mission.id }%>
             <%= f.button :submit, value: t('.save') %>
           <% end %>
         </li>
       </ul>
-    <%= link_to t('.destroy'), admin_group_adventure_mission_group_path(@group, @adventure_mission_group), method: :delete, data: { confirm: t('.confirm_destroy'), class: 'btn danger'}%>
+    <%= link_to t('.destroy'), admin_adventure_mission_group_path(@adventure_mission_group), method: :delete, data: { confirm: t('.confirm_destroy') } , class: 'btn danger' %>
 </div>

--- a/app/views/admin/adventure_missions/_form.html.erb
+++ b/app/views/admin/adventure_missions/_form.html.erb
@@ -7,5 +7,6 @@
   <%= f.input :max_points %>
   <%= f.input :variable_points %>
   <%= f.input :index , input_html: { value: suggested_index } %>
+  <%= f.input :locked %>
   <%= f.button :submit %>
 <% end %>

--- a/app/views/admin/adventure_missions/_sidebar.html.erb
+++ b/app/views/admin/adventure_missions/_sidebar.html.erb
@@ -10,4 +10,16 @@
       <%= icon('fas', 'plus', t('.add')) %>
     <% end %>
   </li>
+
+  <li class="list-group-item">
+    <%= link_to(admin_adventure_lock_path(adventure)) do %>
+      <%= icon('fas', 'lock', 'Lock all missions') %>
+    <% end %>
+  </li>
+
+  <li class="list-group-item">
+    <%= link_to(admin_adventure_unlock_path(adventure)) do %>
+      <%= icon('fas', 'lock-open', 'Unlock all missions') %>
+    <% end %>
+  </li>
 </ul>

--- a/app/views/admin/adventure_missions/_sidebar.html.erb
+++ b/app/views/admin/adventure_missions/_sidebar.html.erb
@@ -12,14 +12,14 @@
   </li>
 
   <li class="list-group-item">
-    <%= link_to(admin_adventure_lock_path(adventure)) do %>
-      <%= icon('fas', 'lock', 'Lock all missions') %>
+    <%= link_to(admin_adventure_lock_path(adventure), method: :patch) do %>
+      <%= icon('fas', 'lock', t('.lock')) %>
     <% end %>
   </li>
 
   <li class="list-group-item">
-    <%= link_to(admin_adventure_unlock_path(adventure)) do %>
-      <%= icon('fas', 'lock-open', 'Unlock all missions') %>
+    <%= link_to(admin_adventure_unlock_path(adventure), method: :patch) do %>
+      <%= icon('fas', 'lock-open', t('.unlock')) %>
     <% end %>
   </li>
 </ul>

--- a/app/views/admin/adventure_missions/index.html.erb
+++ b/app/views/admin/adventure_missions/index.html.erb
@@ -19,6 +19,10 @@
     end
 
     g.column(name: AdventureMission.human_attribute_name(:max_points), attribute: 'max_points', filter: false)
+    g.column(name: AdventureMission.human_attribute_name(:locked), attribute: 'locked', filter: false) do |a|
+      if a.locked? then t('global.yes') else t('global.no') end
+    end
+
     g.column(name: t('global.edit')) do |a|
       link_to t('global.edit'), edit_admin_adventure_adventure_mission_path(@adventure, a)
     end

--- a/app/views/admin/groups/adventures.html.erb
+++ b/app/views/admin/groups/adventures.html.erb
@@ -17,8 +17,11 @@
       g.column(name: t('.points'), attribute: 'points', filter: false) do |amg|
         amg.points
       end
+      g.column(name: AdventureMission.human_attribute_name(:locked), attribute: 'locked', assoc: :adventure_mission, filter: false) do |amg|
+        if amg.adventure_mission.locked? then t('global.yes') else t('global.no') end
+      end
       g.column(filter: false) do |amg|
-        link_to t('.edit'), edit_admin_group_adventure_mission_group_path(@group, amg)
+        link_to t('.edit'), edit_admin_adventure_mission_group_path(amg)
       end
     end -%>
 </div>

--- a/app/views/adventure_mission_groups/edit.html.erb
+++ b/app/views/adventure_mission_groups/edit.html.erb
@@ -1,17 +1,16 @@
 <div class="col-md-12 introduction">
   <h1><%= t('.update') %></h1>
    <ul class="list-group">
-        <li class="list-group-item">
-          <span class="badge"><%= @adventure_mission.max_points %></span>
-          <%= Adventure.human_attribute_name(:max_points) %>
-        </li>
-        <li class="list-group-item">
-          <%= simple_form_for(@adventure_mission_group) do |f| %>
-            <%= f.input :points %>
-            <%= f.input :adventure_mission_id, as: :hidden, input_html: { value: @adventure_mission.id }%>
-            <%= f.button :submit, value: t('.save') %>
-          <% end %>
-        </li>
-      </ul>
-  <p>
+      <li class="list-group-item">
+        <span class="badge"><%= @adventure_mission.max_points %></span>
+        <%= AdventureMission.human_attribute_name(:max_points) %>
+      </li>
+      <li class="list-group-item">
+        <%= simple_form_for(@adventure_mission_group) do |f| %>
+          <%= f.input :points %>
+          <%= f.input :adventure_mission_id, as: :hidden, input_html: { value: @adventure_mission.id }%>
+          <%= f.button :submit, value: t('.save') %>
+        <% end %>
+      </li>
+    </ul>
 </div>

--- a/app/views/adventure_mission_groups/new.html.erb
+++ b/app/views/adventure_mission_groups/new.html.erb
@@ -3,7 +3,7 @@
    <ul class="list-group">
         <li class="list-group-item">
           <span class="badge"><%= @adventure_mission.max_points %></span>
-          <%= Adventure.human_attribute_name(:max_points) %>
+          <%= AdventureMission.human_attribute_name(:max_points) %>
         </li>
         <li class="list-group-item">
 

--- a/app/views/adventure_missions/show.html.erb
+++ b/app/views/adventure_missions/show.html.erb
@@ -4,10 +4,23 @@
     <h1><%= title(@adventure_mission.title) %> - <%= @adventure_mission.index %></h1>
   </div>
 <ul class="list-group">
+<% if @adventure_mission.locked? %>
+    <li class="list-group-item list-group-item-danger">
+    <span class="badge"><%= icon('fa', 'lock') %></span>
+    <%= t('.locked') %>
+  </li>
+  <% else %>
+    <li class="list-group-item list-group-item-success">
+    <span class="badge"><%= icon('fa', 'lock-open') %></span>
+    <%= t('.not_locked') %>
+  <% end %>
+
   <li class="list-group-item">
     <span class="badge"><%= @adventure_mission.max_points %></span>
     <%= AdventureMission.human_attribute_name(:max_points) %>
   </li>
+
+
   <% if @adventure_mission_group.present? %>
     <% @class = 'success' %>
     <% @icon = 'check' %>
@@ -54,10 +67,12 @@
                                                   class: 'btn primary' %>
       <% end %>
     <% else %>
-      <% if @adventure_mission.variable_points? %>
-        <%= link_to t('.update_points'), edit_adventure_mission_group_path(@adventure_mission_group), method: 'get', class: 'btn primary' %>
+      <% if !@adventure_mission.locked? %>
+        <% if @adventure_mission.variable_points? %>
+          <%= link_to t('.update_points'), edit_adventure_mission_group_path(@adventure_mission_group), method: 'get', class: 'btn primary' %>
+        <% end %>
+        <%= link_to t('.reset_points'), adventure_mission_group_path(@adventure_mission_group), method: 'delete', class: 'btn danger' %>
       <% end %>
-      <%= link_to t('.reset_points'), adventure_mission_group_path(@adventure_mission_group, adventure_mission: @adventure_mission), method: 'delete', class: 'btn danger' %>
     <% end %>
     <% end %>
     <%= link_to(t('adventures.show.index'), adventures_path, class: 'btn secondary') %>

--- a/app/views/adventures/_adventure_view.html.erb
+++ b/app/views/adventures/_adventure_view.html.erb
@@ -36,11 +36,11 @@
 
                 g.column(name: AdventureMission.human_attribute_name(:max_points), attribute: 'max_points', filter: false, ordering: false)
                 g.column(name: t('.finished'), filter: true) do |a|
-                  if a.finished?(current_user.groups.regular.last)
-                    'Ja'
-                  else
-                    'Nej'
-                  end
+                  if a.finished?(current_user.groups.regular.last) then t('global.yes') else t('global.no') end
+                end
+
+                g.column(name: AdventureMission.human_attribute_name(:locked), filter: true) do |a|
+                  if a.locked? then t('global.yes') else t('global.no') end
                 end
 
                 g.column(name: t('.points'), filter: false) do |a|
@@ -48,7 +48,7 @@
                 end
 
                 g.column(name: '', filter: false) do |a|
-                  link_to t('.read_more'), adventure_adventure_mission_path(@adventure, a)
+                  link_to t('.read_more'), adventure_mission_path(a)
                 end
               end -%>
           </div>

--- a/app/views/layouts/_content.html.erb
+++ b/app/views/layouts/_content.html.erb
@@ -1,16 +1,37 @@
 <div class="container content">
   <% if notice %>
-    <div class="alert alert-info">
+    <% notice_type = 'info' %>
+    <% notice_text = '' %>
+    <% if notice.is_a? Hash %>
+      <% notice_type = notice.key?('type') || notice.key?(:type) ? notice['type'] || notice[:type] : 'info' %>
+      <% notice_text = notice['text'] || notice[:text] %>
+    <% else %>
+      <% notice_text = notice %>
+    <% end %>
+
+    <div class="alert alert-<%= notice_type %>">
       <button type="button" class="close" data-dismiss="alert">&times;</button>
-      <%= notice %>
+      <%= notice_text %>
     </div>
   <% end %>
 
   <% if alert %>
-    <div class="alert alert-danger fade-in">
-      <button type="button" class="close" data-dismiss="alert">&times;</button>
-      <strong><%= t('.error') %> </strong> <%= alert %>
-    </div>
+
+    <% if alert['type'] == 'errors' %>
+        <div class="alert alert-danger">
+          <button type="button" class="close" data-dismiss="alert">&times;</button>
+
+          <% for error in alert['errors'] %>
+            <strong><%= t('.error') %> </strong> <%= error %> <br>
+
+          <% end %>
+        </div>
+    <% else %>
+      <div class="alert alert-danger fade-in">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <strong><%= t('.error') %> </strong> <%= alert %>
+      </div>
+    <% end %>
   <% end %>
 
   <%= yield %>

--- a/config/locales/defaults/errors.sv.yml
+++ b/config/locales/defaults/errors.sv.yml
@@ -23,8 +23,8 @@ sv:
       present: '%{attribute} måste vara blankt'
       record_invalid: 'Ett fel uppstod: %{errors}'
       restrict_dependent_destroy:
-        one: Kan inte förinta objektet då det finns ett beroende %{record}
-        other: Kan inte förinta objektet då det finns beroende %{record}
+        has_one: Kan inte förinta objektet då det finns ett beroende %{record}
+        has_many: Kan inte förinta objektet då det finns beroende %{record}
       required: '%{attribute} måste anges'
       taken: '%{attribute} används redan'
       too_long: '%{attribute} är för lång (maximum är %{count} tecken)'

--- a/config/locales/models/adventure.sv.yml
+++ b/config/locales/models/adventure.sv.yml
@@ -16,3 +16,11 @@ sv:
         end_date: Slutar
         publish_results: Publicera resultaten
         groups: Faddergrupper
+
+    errors:
+      models:
+        adventure:
+          attributes:
+            base:
+              restrict_dependent_destroy:
+                has_many: "Detta äventyr har tillhörande uppdrag och kan därför inte raderas. Radera uppdragen först."

--- a/config/locales/models/adventure_mission.sv.yml
+++ b/config/locales/models/adventure_mission.sv.yml
@@ -18,3 +18,11 @@ sv:
         publish_results: Publicera resultaten
         groups: Faddergrupper
         index: Nummer
+
+    errors:
+      models:
+        adventure_mission:
+          attributes:
+            base:
+              restrict_dependent_destroy:
+                has_many: "Grupper har redan avslutat detta uppdrag. Uppdraget går därför inte att radera."

--- a/config/locales/models/adventure_mission.sv.yml
+++ b/config/locales/models/adventure_mission.sv.yml
@@ -13,6 +13,7 @@ sv:
         description_sv: Beskrivning - svenska
         description_en: Beskrivning - engelska
         max_points: Maxpoäng
+        locked: Låst
         variable_points: Varierbar poäng
         publish_results: Publicera resultaten
         groups: Faddergrupper

--- a/config/locales/models/adventure_mission_group.sv.yml
+++ b/config/locales/models/adventure_mission_group.sv.yml
@@ -3,6 +3,11 @@ sv:
     attributes:
       adventure_mission_group:
         points: Poäng
+    models:
+      adventure_mission_group:
+        one: Avslutat äventyrsuppdrag
+        other: Avslutade äventyrsuppdrag
   model:
     adventure_mission_group:
       invalid_points: "0 < Poäng <= %{max_points}"
+      locked: Äventyrsuppdraget är låst

--- a/config/locales/onesky_en/errors.en.yml
+++ b/config/locales/onesky_en/errors.en.yml
@@ -30,8 +30,8 @@ en:
       present: "must be blank"
       record_invalid: "Validation failed: %{errors}"
       restrict_dependent_destroy:
-        one: "Cannot delete record because a dependent %{record} exists"
-        other: ""
+        has_one: "Cannot delete record because a dependent %{record} exists"
+        has_many: ""
       required: "can't be empty"
       taken: "has already been taken"
       too_long: "is too long (maximum is %{count} characters)"

--- a/config/locales/views/admin/adventure_missions/adventure_missions_admin.sv.yml
+++ b/config/locales/views/admin/adventure_missions/adventure_missions_admin.sv.yml
@@ -19,3 +19,5 @@ sv:
       sidebar:
         edit: Redigera äventyr
         add: Lägg till uppdrag
+        lock: Lås alla uppdrag
+        unlock: Lås upp alla uppdrag

--- a/config/locales/views/admin/adventures/adventures_admin.sv.yml
+++ b/config/locales/views/admin/adventures/adventures_admin.sv.yml
@@ -17,3 +17,9 @@ sv:
         all: Alla äventyr
         add_mission: Lägg till uppdrag
         all_missions: Alla uppdrag
+      lock:
+        success: Äventyr låst
+        fail: Kunde inte låsa äventyr
+      unlock:
+        success: Äventyr upplåst
+        fail: Kunde inte låsa upp äventyr

--- a/config/locales/views/adventure_mission_groups/adventure_mission_groups.sv.yml
+++ b/config/locales/views/adventure_mission_groups/adventure_mission_groups.sv.yml
@@ -5,12 +5,15 @@ sv:
     edit:
       update: Ändra poäng
       save: Spara poäng
+      locked: Uppdraget är låst
     create:
       success: Uppdrag slutfört
       fail: Kunde inte slutföra uppdrag
+      locked: Uppdraget är låst
     update:
       success: Uppdrag uppdaterat
       fail: Kunde inte uppdatera uppdrag
+      locked: Uppdraget är låst
     destroy:
       success: Uppdrag återställt
       fail: Kunde inte återställa uppdrag

--- a/config/locales/views/adventure_mission_groups/adventure_mission_groups.sv.yml
+++ b/config/locales/views/adventure_mission_groups/adventure_mission_groups.sv.yml
@@ -17,3 +17,4 @@ sv:
     destroy:
       success: Uppdrag återställt
       fail: Kunde inte återställa uppdrag
+      locked: Du kan inte återställa poängen då uppdraget är låst

--- a/config/locales/views/adventure_missions/adventure_missions.sv.yml
+++ b/config/locales/views/adventure_missions/adventure_missions.sv.yml
@@ -13,3 +13,5 @@ sv:
       update_points: Uppdatera poäng
       reset_points: Återställ poäng
       no_group: Du måste vara med i en faddergrupp för att göra detta
+      locked: Äventyrsuppdraget är låst
+      not_locked: Äventyrsuppdraget går att slutföra

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Fsek::Application.routes.draw do
     post 'anvandare/skapa' => 'registrations#create', as: :user_registration
     get 'anvandare/registrera' => 'devise/registrations#new', as: :new_user_registration
 
-    #sessions
+    # sessions
     get 'logga-in' => 'devise/sessions#new', as: :new_user_session
     get 'logga_in', to: redirect('logga-in'), status: 301
     post 'logga-in' => 'devise/sessions#create', as: :user_session
@@ -44,7 +44,7 @@ Fsek::Application.routes.draw do
   end
 
   # Scope to change urls to swedish
-  scope path_names: {new: 'ny', edit: 'redigera'} do
+  scope path_names: { new: 'ny', edit: 'redigera' } do
     resources :tools, path: :verktyg, only: [:show, :index]
 
     namespace :admin do
@@ -144,16 +144,11 @@ Fsek::Application.routes.draw do
     resources :adventures, path: :aventyr, only: [:index, :show] do
       get :archive, on: :collection, path: :arkiv
       get :highscore, on: :collection
-      resources :adventure_missions, only: [:index, :show], path: :aventyrsuppdrag
     end
 
-    resources :adventure_mission_groups
+    resources :adventure_missions, path: :aventyrsuppdrag
 
-    namespace :admin do
-      resources :groups do
-        resources :adventure_mission_groups
-      end
-    end
+    resources :adventure_mission_groups, path: :avslutade_aventyrsuppdrag
 
     namespace :admin do
       resources :introductions, path: :nollning do
@@ -161,10 +156,12 @@ Fsek::Application.routes.draw do
       end
 
       resources :adventures, path: :aventyr do
-        get :lock
-        get :unlock
+        patch :lock
+        patch :unlock
         resources :adventure_missions, path: :aventyrsuppdrag
       end
+
+      resources :adventure_mission_groups, path: :avslutade_aventyrsuppdrag
     end
 
     resources :councils, path: :utskott, only: [:index, :show]
@@ -203,7 +200,7 @@ Fsek::Application.routes.draw do
       post :mail, on: :member
     end
 
-    resources :calendars, path: :kalender,  only: :index do
+    resources :calendars, path: :kalender, only: :index do
       get :export, on: :collection
       get :introduction, on: :collection, path: :nollning
     end
@@ -239,7 +236,6 @@ Fsek::Application.routes.draw do
     namespace :admin do
       resources :documents, path: :dokument, except: :show
     end
-
 
     namespace :admin do
       resources :elections, path: :val do
@@ -335,7 +331,7 @@ Fsek::Application.routes.draw do
       resources :meetings, path: :lokalbokning
     end
 
-    resources :songs, path: :sangbok, only: [:index, :show]  do
+    resources :songs, path: :sangbok, only: [:index, :show] do
       post :search, on: :collection
     end
 
@@ -344,7 +340,6 @@ Fsek::Application.routes.draw do
     end
 
     namespace :admin do
-
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,8 @@ Fsek::Application.routes.draw do
       end
 
       resources :adventures, path: :aventyr do
+        get :lock
+        get :unlock
         resources :adventure_missions, path: :aventyrsuppdrag
       end
     end

--- a/db/migrate/20190301162700_add_locked_attribute_to_adventures.rb
+++ b/db/migrate/20190301162700_add_locked_attribute_to_adventures.rb
@@ -1,0 +1,5 @@
+class AddLockedAttributeToAdventures < ActiveRecord::Migration[5.0]
+  def change
+    add_column(:adventure_missions, :locked, :boolean, default: true, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 20190410192700) do
     t.integer "adventure_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "locked", default: true, null: false
     t.index ["adventure_id"], name: "index_adventure_missions_on_adventure_id"
   end
 

--- a/spec/controllers/concerns/alerts_spec.rb
+++ b/spec/controllers/concerns/alerts_spec.rb
@@ -30,17 +30,20 @@ describe Alerts, type: :concern do
   describe 'alerts' do
     it '#alert_update' do
       alert.stub(:model_name) { 'Model' }
-      alert.alert_update(nil).should eq("Model #{I18n.t('global_controller.success_update')}.")
+      alert.alert_update(nil).should eq(text: "Model #{I18n.t('global_controller.success_update')}.",
+                                        type: 'success')
     end
 
     it '#alert_create' do
       alert.stub(:model_name) { 'Model' }
-      alert.alert_create(nil).should eq("Model #{I18n.t('global_controller.success_create')}.")
+      alert.alert_create(nil).should eq(text: "Model #{I18n.t('global_controller.success_create')}.",
+                                        type: 'success')
     end
 
     it '#alert_destroy' do
       alert.stub(:model_name) { 'Model' }
-      alert.alert_destroy(nil).should eq("Model #{I18n.t('global_controller.success_destroy')}.")
+      alert.alert_destroy(nil).should eq(text: "Model #{I18n.t('global_controller.success_destroy')}.",
+                                         type: 'danger')
     end
   end
 end

--- a/spec/features/election/candidate_spec.rb
+++ b/spec/features/election/candidate_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Visit Election', type: :feature do
     select(user, from: 'candidate_user_id')
     find('#candidate-submit').click
 
-    page.should have_css('div.alert.alert-info')
-    find('div.alert.alert-info').text.should include(I18n.t('global_controller.success_create'))
+    page.should have_css('div.alert.alert-success')
+    find('div.alert.alert-success').text.should include(I18n.t('global_controller.success_create'))
   end
 end

--- a/spec/features/election/nomination_spec.rb
+++ b/spec/features/election/nomination_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Visit Election', type: :feature do
     find('#nomination-submit').click
 
     page.status_code.should eq(200)
-    page.should have_css('div.alert.alert-info')
-    find('div.alert.alert-info').text.should include(I18n.t('global_controller.success_create'))
+    page.should have_css('div.alert.alert-success')
+    find('div.alert.alert-success').text.should include(I18n.t('global_controller.success_create'))
   end
 end

--- a/spec/features/user/account_spec.rb
+++ b/spec/features/user/account_spec.rb
@@ -8,9 +8,9 @@ RSpec.feature 'Update account', type: :feature do
 
     fill_in('user_student_id', with: %(tfy#{Time.zone.now.year - 2000}ggg))
     click_button('user-info-submit')
-    page.should have_css('div.alert.alert-info')
+    page.should have_css('div.alert.alert-success')
 
-    find('div.alert.alert-info').text.should include(I18n.t('global_controller.success_update'))
+    find('div.alert.alert-success').text.should include(I18n.t('global_controller.success_update'))
     page.should have_http_status(200)
 
     user.reload


### PR DESCRIPTION
Now admins can lock adventures when they can no longer be submitted. This requires some minor changes in the app where we need to check whether a mission is locked or not and display some indication. Closes #847 