### PR TITLE
Add API endpoint for introduction matrix

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -58,7 +58,7 @@ class Ability
       can [:index, :visit, :look, :look_all], Notification, user_id: user.id
       can [:create, :destroy], PushDevice
       can :index, :start
-      can [:read, :scroll], :api_event
+      can [:read, :scroll, :matrix], :api_event
       can [:create, :destroy], Fredmansky
     end
 

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -8,6 +8,7 @@ class EventSerializer < ActiveModel::Serializer
   attribute(:recurring) { false }
   attribute(:url) { Rails.application.routes.url_helpers.event_path(object.id) }
   attribute(:textColor) { 'black' }
+  attribute(:dot)
   has_one :event_signup
 
   has_one :event_user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -360,6 +360,7 @@ Fsek::Application.routes.draw do
 
     resources :events, only: [:index, :show] do
       get :scroll, on: :collection
+      get :matrix, on: :collection
       resources :event_users, only: [:create, :destroy]
     end
 


### PR DESCRIPTION
This PR adds an API endpoint that fetches all events between the `start` and `stop` date of the current `Introduction` and then groups these by week. 

Also adds the `:dot` attribute to the `EventSerializer`.