### PR TITLE
New Info group type

### DIFF
--- a/app/assets/stylesheets/partials/_groups.scss
+++ b/app/assets/stylesheets/partials/_groups.scss
@@ -26,3 +26,9 @@
     }
   }
 }
+
+.new_message textarea.disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  pointer-events: none;
+}

--- a/app/channels/groups_channel.rb
+++ b/app/channels/groups_channel.rb
@@ -14,7 +14,7 @@ class GroupsChannel < ApplicationCable::Channel
 
   def send_message(data)
     group = Group.find(data['group_id'])
-    return unless ability.can?(:show, group)
+    return unless ability.can?(:show, group) && !group.info?
 
     params = { content: data['content'] }
     MessageService.create_message(params, [group], current_user)

--- a/app/helpers/group_helper.rb
+++ b/app/helpers/group_helper.rb
@@ -35,15 +35,24 @@ module GroupHelper
         Group.human_attribute_name('regular')
       elsif group.mission?
         Group.human_attribute_name('mission')
+      elsif group.info?
+        Group.human_attribute_name('info')
       else
         Group.human_attribute_name('other')
       end
     end
   end
 
+  def group_type_event_collection
+    [[Group.human_attribute_name('regular'), Group::REGULAR],
+     [Group.human_attribute_name('mission'), Group::MISSION],
+     [Group.human_attribute_name('other'), Group::OTHER]]
+  end
+
   def group_type_collection
     [[Group.human_attribute_name('regular'), Group::REGULAR],
      [Group.human_attribute_name('mission'), Group::MISSION],
+     [Group.human_attribute_name('info'), Group::INFO],
      [Group.human_attribute_name('other'), Group::OTHER]]
   end
 end

--- a/app/models/events/event_signup.rb
+++ b/app/models/events/event_signup.rb
@@ -55,7 +55,7 @@ class EventSignup < ApplicationRecord
   end
 
   def selectable_groups
-    group_types.present? ? Group.where(group_type: group_types) : Group.all
+    group_types.present? ? Group.where(group_type: group_types) : Group.event_groups
   end
 
   # Loops through options by order and checks if user fits

--- a/app/models/groups/group.rb
+++ b/app/models/groups/group.rb
@@ -11,16 +11,19 @@ class Group < ApplicationRecord
 
   REGULAR = 'regular'.freeze
   MISSION = 'mission'.freeze
+  INFO = 'info'.freeze
   OTHER = 'other'.freeze
 
   validates :name, presence: true
   validates :number, presence: true, numericality: { greater_than: 0 }, if: :regular?
   validates :number, absence: true, unless: :regular?
-  validates :group_type, presence: true, inclusion: { in: [REGULAR, MISSION, OTHER] }
+  validates :group_type, presence: true, inclusion: { in: [REGULAR, MISSION, INFO, OTHER] }
 
   scope :regular, -> { where(group_type: REGULAR) }
   scope :missions, -> { where(group_type: MISSION) }
+  scope :info, -> { where(group_type: INFO) }
   scope :others, -> { where(group_type: OTHER) }
+  scope :event_groups, -> { where.not(group_type: INFO) }
   scope :for_show, -> { includes(:introduction) }
 
   # TODO add method to find the group with the most points
@@ -31,6 +34,10 @@ class Group < ApplicationRecord
 
   def mission?
     group_type == MISSION
+  end
+
+  def info?
+    group_type == INFO
   end
 
   def other?

--- a/app/serializers/api/group_serializer.rb
+++ b/app/serializers/api/group_serializer.rb
@@ -1,5 +1,5 @@
 class Api::GroupSerializer < ActiveModel::Serializer
-  attributes(:id, :name)
+  attributes(:id, :name, :group_type)
 
   has_many(:messages) do
     object.messages.includes(:user).by_latest.limit(3)

--- a/app/views/admin/event_signups/_form.html.erb
+++ b/app/views/admin/event_signups/_form.html.erb
@@ -30,7 +30,7 @@
     <h4><%= t('.groups') %></h4>
   </div>
   <%= f.input :group_types, input_html: {class: 'select2', multiple: true},
-                            collection: group_type_collection,
+                            collection: group_type_event_collection,
                             include_hidden: false %>
   <%= f.button :submit %>
   <% if event.persisted? && signup.try(:persisted?) %>

--- a/app/views/messages/_new.html.erb
+++ b/app/views/messages/_new.html.erb
@@ -1,6 +1,14 @@
 <div>
-  <%= form_for([group, message], url: '#') do |f| %>
-    <%= f.text_area :content, input_html: {rows: 2}, class: 'form-control margin-bottom-10' %>
-    <%= f.submit 'Skicka', class: 'btn primary' %>
+  <% if @group.info? %>
+    <%= form_for([group, message], url: '#') do |f| %>
+      <%= f.text_area :content, input_html: {rows: 2}, value: I18n.t('groups.show.read_only'), class: 'form-control margin-bottom-10 disabled' %>
+      <%= f.submit I18n.t('groups.show.send'), class: 'btn primary disabled' %>
+    <% end %>
+  <% else %>
+    <%= form_for([group, message], url: '#') do |f| %>
+      <%= f.text_area :content, input_html: {rows: 2}, class: 'form-control margin-bottom-10' %>
+      <%= f.submit I18n.t('groups.show.send'), class: 'btn primary' %>
+    <% end %>
   <% end %>
+
 </div>

--- a/config/locales/views/groups/groups.sv.yml
+++ b/config/locales/views/groups/groups.sv.yml
@@ -9,6 +9,8 @@ sv:
       messages: Meddelanden
       all_messages: Alla meddelanden
       new_message: Nytt meddelande
+      send: Skicka
+      read_only: Chatten är skrivskyddad
 
     edit:
       back: Tillbaka


### PR DESCRIPTION
- Adds a new group type `info`
  - Can be used with similar scopes and checks like the other group types
  - Is read-only by adding an additional requirement in `group_channel.rb` on the group type not being `info`. The only way to send messages is by using the introduction admin interface
- New event collection in `group_helper.rb` to filter out info groups in event signup creation (admin)
- Adds an `event_groups` scope to filter out info groups in event signup
- Adds the group type to the serializer for the handling of this in the app
- Closes #949 