### PR TITLE
Fixes event signup bug and adventure week number

### DIFF
--- a/app/models/adventures/adventure.rb
+++ b/app/models/adventures/adventure.rb
@@ -24,7 +24,7 @@ class Adventure < ApplicationRecord
 
   def week_number
     # Just making sure the dates don't extend into another week
-    (end_date - 3.days).strftime('%U').to_i
+    (end_date - 3.days).strftime('%U').to_i + 1
   end
 
   def self.can_show?(user)

--- a/app/models/groups/group_user.rb
+++ b/app/models/groups/group_user.rb
@@ -6,11 +6,19 @@ class GroupUser < ApplicationRecord
   validates :user, uniqueness: { scope: :group }
 
   scope :novices, -> (introduction: Introduction.current) do
-    includes(:group).where(fadder: false, groups: { introduction_id: introduction })
+    includes(:group).where(fadder: false,
+                           groups: {
+                             introduction_id: introduction,
+                             group_type: [Group::REGULAR, Group::MISSION]
+                           })
   end
 
   scope :mentors, -> (introduction: Introduction.current) do
-    includes(:group).where(fadder: true, groups: { introduction_id: introduction })
+    includes(:group).where(fadder: true,
+                           groups: {
+                             introduction_id: introduction,
+                             group_type: [Group::REGULAR, Group::MISSION]
+                           })
   end
 
   def to_partial_path


### PR DESCRIPTION
- We now only see users as novices or mentors if they are marked as such in either a regular och mission group during the current introduction. Before, a user was seen as a novice if they were one in any of the groups causing a problem with the new info group type, where everyone is a novice.
- Increments the week number on the adventure since the first week of January was seen as 0 