### PR TITLE
fix styling for long titles and links

### DIFF
--- a/app/assets/stylesheets/partials/_news.scss
+++ b/app/assets/stylesheets/partials/_news.scss
@@ -1,4 +1,7 @@
 .news {
+
+  word-break: break-word;
+
   .info {
     margin-bottom: 15px;
     margin-top: -5px;

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -376,8 +376,8 @@ ActiveRecord::Schema.define(version: 20190821201800) do
     t.string "group_types"
     t.datetime "sent_reminder"
     t.datetime "sent_position"
-    t.datetime "sent_closing"
     t.datetime "sent_open"
+    t.datetime "sent_closing"
     t.index ["deleted_at"], name: "index_event_signups_on_deleted_at"
     t.index ["event_id"], name: "index_event_signups_on_event_id"
   end
@@ -946,9 +946,9 @@ ActiveRecord::Schema.define(version: 20190821201800) do
     t.integer "notifications_count", default: 0, null: false
     t.boolean "notify_event_users", default: true, null: false
     t.boolean "notify_messages", default: true, null: false
-    t.boolean "notify_event_closing", default: false, null: false
     t.integer "terms_version", default: 0, null: false
     t.boolean "notify_event_open", default: false, null: false
+    t.boolean "notify_event_closing", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Styling so that words stay inside their box in the news feed 
closes #948  
(only fixes website)