### PR TITLE
Devise Tokens: Increase lifespan and number of devices

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -7,11 +7,11 @@ DeviseTokenAuth.setup do |config|
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  config.token_lifespan = 4.weeks
+  config.token_lifespan = 1.year
 
   # Sets the max number of concurrent devices per user, which is 10 by default.
   # After this limit is reached, the oldest tokens will be removed.
-  # config.max_number_of_devices = 10
+  config.max_number_of_devices = 100
 
   # Sometimes it's necessary to make several requests to the API at the same
   # time. In this case, each request in the batch will need to share the same


### PR DESCRIPTION
This should prevent users from being signed out so often.
Extends the token lifespan to 1 year (was 4 weeks).
Allows up to 100 devices per user (was 10). Useful for Spindelmän doing tests :)

NOTE: The proper way to solve this issue would be to use a refresh token
to update the auth token when it is about to expire. Devise token auth
and jtoker do not however support this feature at this momement