### PR TITLE
Changing event priority to be more logical and robust 

### DIFF
--- a/app/models/events/event_signup.rb
+++ b/app/models/events/event_signup.rb
@@ -61,7 +61,7 @@ class EventSignup < ApplicationRecord
   # Loops through options by order and checks if user fits
   def highest_type(user)
     (order - [CUSTOM]).each do |type|
-      if type == NOVICE && user.novice?
+      if type == NOVICE && user.novice? && !user.mentor?
         return NOVICE
       elsif type == MENTOR && user.mentor?
         return MENTOR

--- a/spec/models/event_signup_spec.rb
+++ b/spec/models/event_signup_spec.rb
@@ -36,17 +36,17 @@ RSpec.describe EventSignup, type: :model do
       user.stub(:member?).and_return(true)
       event_signup.selectable_types(user).should eq([EventSignup::MEMBER,
                                                      EventSignup::CUSTOM])
+      
+      user.stub(:novice?).and_return(true)
+      event_signup.selectable_types(user).should eq([EventSignup::NOVICE,
+                                                     EventSignup::CUSTOM])
 
       user.stub(:mentor?).and_return(true)
       event_signup.selectable_types(user).should eq([EventSignup::MENTOR,
                                                      EventSignup::CUSTOM])
 
-      user.stub(:novice?).and_return(true)
-      event_signup.selectable_types(user).should eq([EventSignup::NOVICE,
-                                                     EventSignup::CUSTOM])
-
       event_signup.custom = nil
-      event_signup.selectable_types(user).should eq([EventSignup::NOVICE])
+      event_signup.selectable_types(user).should eq([EventSignup::MENTOR])
     end
 
     it 'returns nil if no suiting type' do


### PR DESCRIPTION
A user can be both novice and mentor if the groups are wrongly configured (for example if the user is mentor in a mission group and novice in a normal group). If that is the case, the user can only choose to be a novice (or other, but not as a mentor). Now that user can not choose to be a novice and only a mentor.