### PR TITLE
Trim firstname and lastname on user creation

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [:email, :firstname, :lastname]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the


### PR DESCRIPTION
I don't know how this is an issue, but `firstname`  nor `lastname` gets trimmed on user creation. Someone can create a user with the first name "Fredrik " and that gets saved as is in the database. This PR fixes it so devise trims whitespaces on more than just `email`.