### PR TITLE
Error message fix for limited council posts

### DIFF
--- a/app/services/post_user_service.rb
+++ b/app/services/post_user_service.rb
@@ -3,7 +3,7 @@ module PostUserService
     post_user.validate
 
     if post_user.post.try(:limited?)
-      post_user.errors.add(:post, I18n.t('post.limited'))
+      post_user.errors.add(:post, I18n.t('service.post_user.limited'))
       return false
     end
 

--- a/config/locales/services/post_user_service.sv.yml
+++ b/config/locales/services/post_user_service.sv.yml
@@ -1,0 +1,4 @@
+sv:
+  service:
+    post_user:
+      limited: Begränsad


### PR DESCRIPTION
There was an error with there not being a translation for a post being limited to x amount of people, the error message is now hard coded in swedish since it's on an admin page.

Closes #1002 