### PR TITLE
fix for limited post error message

### DIFF
--- a/app/services/post_user_service.rb
+++ b/app/services/post_user_service.rb
@@ -3,7 +3,7 @@ module PostUserService
     post_user.validate
 
     if post_user.post.try(:limited?)
-      post_user.errors.add(:post, I18n.t('post.limited'))
+      post_user.errors.add(:post, I18n.t('service.post_user.limited'))
       return false
     end
 

--- a/config/locales/services/post_user_service.sv.yml
+++ b/config/locales/services/post_user_service.sv.yml
@@ -1,0 +1,4 @@
+sv:
+  service:
+    post_user:
+      limited: Posten är begränsad


### PR DESCRIPTION
There was an error with there not being a translation for a post being limited to x amount of people, correctly linked with a new yml file for post_user_service.

Closes #1002