### PR TITLE
Pending adventure missions

### DIFF
--- a/app/controllers/admin/adventure_mission_groups_controller.rb
+++ b/app/controllers/admin/adventure_mission_groups_controller.rb
@@ -1,9 +1,16 @@
 class Admin::AdventureMissionGroupsController < Admin::BaseController
   load_permissions_and_authorize_resource
+  load_and_authorize_resource :adventure, :except => [:update]
+  load_and_authorize_resource :group, :only => [:index]
 
   def index
+    if adventure_mission_group_params[:pending].nil?
+      @adventure_mission_group.pending = false
+    else
+      @adventure_mission_group.pending = adventure_mission_group_params[:pending]
+    end
     @grid = initialize_grid(@adventure_mission_groups,
-                            include: [:adventure_mission, :group],
+                            include: [:group, :adventure_mission],
                             per_page: 30)
   end
 
@@ -14,6 +21,7 @@ class Admin::AdventureMissionGroupsController < Admin::BaseController
   def update
     # No validation here since there are admins doing this
     @adventure_mission_group.points = adventure_mission_group_params[:points]
+    @adventure_mission_group.pending = adventure_mission_group_params[:pending]
     if @adventure_mission_group.save(validate: false)
       redirect_to admin_group_adventures_path(group_id: @adventure_mission_group.group.id),
                   notice: alert_success(t('.success'))
@@ -24,18 +32,29 @@ class Admin::AdventureMissionGroupsController < Admin::BaseController
   end
 
   def destroy
-    group = @adventure_mission_group.group
-    if @adventure_mission_group.delete
-      redirect_to admin_group_adventures_path(group_id: group.id), notice: alert_success(t('.success'))
+    @group = @adventure_mission_group.group
+    if @adventure_mission_group.destroy
+      redirect_to admin_group_adventures_path(@group), notice: alert_success(t('.success'))
     else
-      redirect_to edit_admin_adventure_mission_group_path(group: @group),
+      redirect_to edit_admin_group_adventure_mission_group_path(@group, @adventure_mission_group),
                   alert: alert_errors(@adventure_mission_group.errors.full_messages)
+    end
+  end
+
+  def accept
+    @adventure_mission_group = AdventureMissionGroup.find(params[:adventure_mission_group_id])
+    if @adventure_mission_group.update_attribute(:pending, false)
+      redirect_to admin_adventure_adventure_mission_groups_path(@adventure),
+                  notice: alert_success(t('.success'))
+    else
+      redirect_to admin_adventure_adventure_mission_groups_path(@adventure),
+                  alert: alert_danger(t('.fail'))
     end
   end
 
   private
 
   def adventure_mission_group_params
-    params.require(:adventure_mission_group).permit(:points)
+    params.require(:adventure_mission_group).permit(:points, :pending, :adventure)
   end
 end

--- a/app/controllers/admin/adventure_missions_controller.rb
+++ b/app/controllers/admin/adventure_missions_controller.rb
@@ -54,6 +54,6 @@ class Admin::AdventureMissionsController < Admin::BaseController
   def adventure_mission_params
     params.require(:adventure_mission).permit(:title_sv, :title_en, :description_sv,
                                               :description_en, :max_points, :variable_points,
-                                              :index, :locked)
+                                              :index, :locked, :require_acceptance)
   end
 end

--- a/app/controllers/admin/adventures_controller.rb
+++ b/app/controllers/admin/adventures_controller.rb
@@ -2,6 +2,7 @@ class Admin::AdventuresController < Admin::BaseController
   load_permissions_and_authorize_resource
 
   def index
+    set_adventures
     @grid = initialize_grid(@adventures, order: :start_date, locale: :sv)
   end
 
@@ -58,6 +59,15 @@ class Admin::AdventuresController < Admin::BaseController
   end
 
   private
+
+  def set_adventures
+    if params[:introduction].present?
+      introduction = Introduction.find_by!(slug: params[:introduction])
+      @adventures = introduction.adventures
+    else
+      @adventures = Adventure.all
+    end
+  end
 
   def adventure_params
     params.require(:adventure).permit(:title_sv, :title_en, :content_sv, :content_en,

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -43,7 +43,8 @@ class Admin::GroupsController < Admin::BaseController
 
   def adventures
     @group = Group.find(params[:group_id])
-    @adventure_mission_groups = AdventureMissionGroup.where(group: @group)
+    @introduction = @group.introduction
+    @adventure_mission_groups = AdventureMissionGroup.where(group: @group, pending: false)
     @grid = initialize_grid(@adventure_mission_groups,
                             include: :adventure_mission,
                             order: 'adventure_mission_groups.updated_at')

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -43,7 +43,6 @@ class Admin::GroupsController < Admin::BaseController
 
   def adventures
     @group = Group.find(params[:group_id])
-    @introduction = @group.introduction
     @adventure_mission_groups = AdventureMissionGroup.where(group: @group, pending: false)
     @grid = initialize_grid(@adventure_mission_groups,
                             include: :adventure_mission,

--- a/app/controllers/adventure_mission_groups_controller.rb
+++ b/app/controllers/adventure_mission_groups_controller.rb
@@ -11,6 +11,9 @@ class AdventureMissionGroupsController < ApplicationController
     @adventure_mission_group.group = @group
     @adventure_mission = AdventureMission.find(adventure_mission_group_params[:adventure_mission_id])
 
+    # If acceptance is not required, pending defaults to false
+    @adventure_mission_group.pending = true if @adventure_mission.require_acceptance?
+
     if @adventure_mission_group.save
       redirect_to adventure_mission_path(@adventure_mission), notice: alert_success(t('.success'))
     else

--- a/app/controllers/adventure_mission_groups_controller.rb
+++ b/app/controllers/adventure_mission_groups_controller.rb
@@ -50,6 +50,6 @@ class AdventureMissionGroupsController < ApplicationController
   private
 
   def adventure_mission_group_params
-    params.require(:adventure_mission_group).permit(:points, :adventure_mission_id)
+    params.require(:adventure_mission_group).permit(:points, :adventure_mission_id, :pending)
   end
 end

--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -3,7 +3,7 @@ class AdventuresController < ApplicationController
   load_permissions_and_authorize_resource
 
   def index
-    @adventure = @adventures.published.first
+    @adventure = @introduction.adventures.published.first
 
     redirect_to root_path, notice: t('.no_adventure') and return if @adventure.nil?
 

--- a/app/controllers/api/adventure_missions_controller.rb
+++ b/app/controllers/api/adventure_missions_controller.rb
@@ -27,7 +27,8 @@ class Api::AdventureMissionsController < Api::BaseController
     adventure_mission_group = AdventureMissionGroup.new(adventure_mission: adventure_mission,
                                                         group: group,
                                                         points: points,
-                                                        finished: Time.now)
+                                                        finished: Time.now,
+                                                        pending: adventure_mission.require_acceptance?)
 
     if adventure_mission_group.save
       render json: :ok, status: 200

--- a/app/models/adventures/adventure_mission.rb
+++ b/app/models/adventures/adventure_mission.rb
@@ -11,15 +11,25 @@ class AdventureMission < ApplicationRecord
   validates :title_sv, presence: true
   validates :index, numericality: { greater_than_or_equal: 0 }, presence: true
   validates :max_points, numericality: { greater_than: 0 }, presence: true
+  validates :require_acceptance, null: false
 
   scope :by_group, ->(group) { where(group: group) }
 
+  # Mission is regarded finished when a Mentor marked it as such
+  # (a corresponding AdventureMissionGroup exists)
   def finished?(group)
     groups.include?(group)
   end
 
+  # Mission is regarded accepted when an admin has accepted it
+  # (pending == false in the corresponding AdventureMissionGroup)
+  def accepted?(group)
+    finished?(group) && adventure_mission_groups.by_group(group).first.pending == false
+  end
+
   def points(group)
-    if finished?(group)
+    # Points only rewarded once mission is accepted
+    if accepted?(group)
       adventure_mission_groups.by_group(group).first.points.to_i
     else
       0

--- a/app/models/adventures/adventure_mission_group.rb
+++ b/app/models/adventures/adventure_mission_group.rb
@@ -5,6 +5,9 @@ class AdventureMissionGroup < ApplicationRecord
   before_destroy :not_locked
 
   validate :point_validity, :not_locked
+  validates :require_acceptance, null: false
+
+  attr_accessor :require_acceptance
 
   scope :by_group, ->(group) { where(group: group) }
 

--- a/app/serializers/api/adventure_mission_group_serializer.rb
+++ b/app/serializers/api/adventure_mission_group_serializer.rb
@@ -1,6 +1,5 @@
 class Api::AdventureMissionGroupSerializer < ActiveModel::Serializer
   class Api::AdventureMissionGroupSerializer::Index < ActiveModel::Serializer
     attributes :name, :total_points, :finished_missions
-
   end
 end

--- a/app/serializers/api/adventure_mission_serializer.rb
+++ b/app/serializers/api/adventure_mission_serializer.rb
@@ -1,11 +1,17 @@
 class Api::AdventureMissionSerializer < ActiveModel::Serializer
   class Api::AdventureMissionSerializer::Index < ActiveModel::Serializer
-    attributes :id, :title, :max_points, :index, :variable_points, :locked
+    attributes :id, :title, :max_points, :index, :variable_points, :locked, :require_acceptance
     attribute :finished, key: :is_finished
+    attribute :accepted, key: :is_accepted
 
     def finished
       @group = scope[:current_user].groups.regular.last
       object.finished?(@group)
+    end
+
+    def accepted
+      @group = scope[:current_user].groups.regular.last
+      object.accepted?(@group)
     end
   end
 end

--- a/app/views/admin/adventure_mission_groups/edit.html.erb
+++ b/app/views/admin/adventure_mission_groups/edit.html.erb
@@ -1,20 +1,27 @@
 <div class="col-md-12">
-  <h1><%= t('.title') %></h1>
-   <ul class="list-group">
-      <li class="list-group-item">
-          <h3><%= @adventure_mission_group.adventure_mission.title %> </h3>
-        </li>
-        <li class="list-group-item">
-          <span class="badge"><%= @adventure_mission_group.adventure_mission.max_points %></span>
-          <%= AdventureMission.human_attribute_name(:max_points) %>
-        </li>
-        <li class="list-group-item">
-          <%= simple_form_for([:admin, @adventure_mission_group]) do |f| %>
-            <%= f.input :points %>
-            <%= f.input :adventure_mission_id, as: :hidden, input_html: { value: @adventure_mission_group.adventure_mission.id }%>
-            <%= f.button :submit, value: t('.save') %>
-          <% end %>
-        </li>
-      </ul>
-    <%= link_to t('.destroy'), admin_adventure_mission_group_path(@adventure_mission_group), method: :delete, data: { confirm: t('.confirm_destroy') } , class: 'btn danger' %>
+  <div class="headline">
+    <h1><%= "#{title(t('.title'))}" %> </h1>
+  </div>
+
+  <ul class="list-group">
+    <li class="list-group-item">
+        <h3><span><%= @group.name %></span>: <%= @adventure_mission_group.adventure_mission.title %></h3>
+    </li>
+    <li class="list-group-item">
+      <span class="badge"><%= @adventure_mission_group.adventure_mission.max_points %></span>
+      <%= AdventureMission.human_attribute_name(:max_points) %>
+    </li>
+    <li class="list-group-item">
+      <%= simple_form_for([:admin_adventure, @adventure_mission_group]) do |f| %>
+        <%= f.input :points %>
+        <% if @adventure_mission_group.adventure_mission.require_acceptance %>
+          <%= f.input :pending, label: t('.pending'), as: :radio_buttons %>
+        <% end %>
+        <%= f.input :adventure_mission_id, as: :hidden, input_html: { value: @adventure_mission_group.adventure_mission.id } %>
+        <%= f.button :submit %>
+      <% end %>
+    </li>
+  </ul>
+
+  <%= link_to t('.destroy'), admin_group_adventure_mission_group_path(@group, @adventure_mission_group), method: :delete, data: { confirm: t('.confirm_destroy') } , class: 'btn danger' %>
 </div>

--- a/app/views/admin/adventure_mission_groups/index.html.erb
+++ b/app/views/admin/adventure_mission_groups/index.html.erb
@@ -1,0 +1,24 @@
+<div class="headline">
+<h1 class="adventure-missions-groups-heading"><%= t('.accept_missions_for') %>: <span><%= @adventure.title %></span></h1>
+</div>
+
+<div class="col-md-3 col-sm-12">
+  <%= link_to model_name(AdventureMission), admin_adventure_adventure_missions_path(@adventure), class: 'btn secondary' %>
+</div> 
+
+
+<div class="col-md-9 col-sm-12">
+  <%= grid @grid do |g|
+    g.column(name: model_name(Group), attribute: 'name', assoc: :group, filter: false)
+    
+    g.column(name: model_name(AdventureMission), attribute: 'title', assoc: [:adventure_mission, :translations], filter: false) do |amg|
+      amg.adventure_mission.title.truncate(40)
+    end
+
+    g.column(name: AdventureMission.human_attribute_name(:max_points), attribute: 'max_points', assoc: :adventure_mission, filter: false)
+
+    g.column(name: t('.accept'), attribute: 'pending', filter: false) do |amg|
+      link_to t('.accept'), admin_adventure_adventure_mission_group_accept_path(@adventure, amg), method: :patch
+    end
+  end -%>
+</div>

--- a/app/views/admin/adventure_mission_groups/index.html.erb
+++ b/app/views/admin/adventure_mission_groups/index.html.erb
@@ -1,24 +1,47 @@
 <div class="headline">
-<h1 class="adventure-missions-groups-heading"><%= t('.accept_missions_for') %>: <span><%= @adventure.title %></span></h1>
+  <h1 class="adventure-missions-groups-heading"><%= t('.accept_missions_for') %>: <span><%= @adventure.title %></span></h1>
 </div>
 
 <div class="col-md-3 col-sm-12">
   <%= link_to model_name(AdventureMission), admin_adventure_adventure_missions_path(@adventure), class: 'btn secondary' %>
-</div> 
-
+</div>
 
 <div class="col-md-9 col-sm-12">
-  <%= grid @grid do |g|
+  <div class= "headline">
+    <h4><%= t('.await_acceptance') %></h4>
+  </div>
+  <%= grid @grid_pending do |g|
     g.column(name: model_name(Group), attribute: 'name', assoc: :group, filter: false)
-    
+
     g.column(name: model_name(AdventureMission), attribute: 'title', assoc: [:adventure_mission, :translations], filter: false) do |amg|
       amg.adventure_mission.title.truncate(40)
     end
 
+    g.column(name: AdventureMissionGroup.human_attribute_name(:points), attribute: 'points', filter: false)
+
     g.column(name: AdventureMission.human_attribute_name(:max_points), attribute: 'max_points', assoc: :adventure_mission, filter: false)
 
-    g.column(name: t('.accept'), attribute: 'pending', filter: false) do |amg|
+    g.column(name: '', attribute: 'pending', filter: false) do |amg|
       link_to t('.accept'), admin_adventure_adventure_mission_group_accept_path(@adventure, amg), method: :patch
+    end
+  end -%>
+
+  <div class= "headline">
+    <h4><%= t('.accepted') %></h4>
+  </div>
+  <%= grid @grid_accepted do |g|
+    g.column(name: model_name(Group), attribute: 'name', assoc: :group, filter: false)
+
+    g.column(name: model_name(AdventureMission), attribute: 'title', assoc: [:adventure_mission, :translations], filter: false) do |amg|
+      amg.adventure_mission.title.truncate(40)
+    end
+
+    g.column(name: AdventureMissionGroup.human_attribute_name(:points), attribute: 'points', filter: false)
+
+    g.column(name: AdventureMission.human_attribute_name(:max_points), attribute: 'max_points', assoc: :adventure_mission, filter: false)
+
+    g.column(name: '', attribute: 'pending', filter: false) do |amg|
+      link_to t('.decline'), admin_adventure_adventure_mission_group_decline_path(@adventure, amg), method: :patch
     end
   end -%>
 </div>

--- a/app/views/admin/adventure_missions/_form.html.erb
+++ b/app/views/admin/adventure_missions/_form.html.erb
@@ -6,6 +6,7 @@
   <%= f.input :description_en, as: :pagedown, input_html: { preview: true, rows: 10 } %>
   <%= f.input :max_points %>
   <%= f.input :variable_points %>
+  <%= f.input :require_acceptance %>
   <%= f.input :index , input_html: { value: suggested_index } %>
   <%= f.input :locked %>
   <%= f.button :submit %>

--- a/app/views/admin/adventure_missions/_form.html.erb
+++ b/app/views/admin/adventure_missions/_form.html.erb
@@ -1,4 +1,3 @@
-
 <%= simple_form_for([:admin, adventure, adventure_mission]) do |f| %>
   <%= f.input :title_sv,  wrapper_html: {class: 'inline half'} %>
   <%= f.input :title_en,  wrapper_html: {class: 'inline half'} %>

--- a/app/views/admin/adventure_missions/_sidebar.html.erb
+++ b/app/views/admin/adventure_missions/_sidebar.html.erb
@@ -6,7 +6,7 @@
   </li>
 
   <li class="list-group-item">
-    <%= link_to(new_admin_adventure_adventure_mission_path(adventure: adventure)) do %>
+    <%= link_to(new_admin_adventure_adventure_mission_path(adventure)) do %>
       <%= icon('fas', 'plus', t('.add')) %>
     <% end %>
   </li>
@@ -24,4 +24,16 @@
       <% end %>
     </li>
   <% end %>
+
+  <li class="list-group-item">
+    <%= link_to(admin_adventure_adventure_mission_groups_path(adventure)) do %>
+      <%= icon('fas', 'list', t('.acceptance')) %>
+    <% end %>
+  </li>
+
+  <li class="list-group-item">
+    <%= link_to(admin_groups_path(introduction: @adventure.introduction)) do %>
+      <%= icon('fas', 'list', t('.groups')) %>
+    <% end %>
+  </li>
 </ul>

--- a/app/views/admin/adventure_missions/_sidebar.html.erb
+++ b/app/views/admin/adventure_missions/_sidebar.html.erb
@@ -11,6 +11,18 @@
     <% end %>
   </li>
 
+  <li class="list-group-item">
+    <%= link_to(admin_adventure_adventure_mission_groups_path(adventure)) do %>
+      <%= icon('fas', 'list', t('.acceptance')) %>
+    <% end %>
+  </li>
+
+  <li class="list-group-item">
+    <%= link_to(admin_groups_path(introduction: @adventure.introduction)) do %>
+      <%= icon('fas', 'list', t('.groups')) %>
+    <% end %>
+  </li>
+
   <% if not adventure.adventure_missions.empty? %>
     <li class="list-group-item">
       <%= link_to(admin_adventure_lock_path(adventure), method: :patch) do %>
@@ -24,16 +36,4 @@
       <% end %>
     </li>
   <% end %>
-
-  <li class="list-group-item">
-    <%= link_to(admin_adventure_adventure_mission_groups_path(adventure)) do %>
-      <%= icon('fas', 'list', t('.acceptance')) %>
-    <% end %>
-  </li>
-
-  <li class="list-group-item">
-    <%= link_to(admin_groups_path(introduction: @adventure.introduction)) do %>
-      <%= icon('fas', 'list', t('.groups')) %>
-    <% end %>
-  </li>
 </ul>

--- a/app/views/admin/adventures/index.html.erb
+++ b/app/views/admin/adventures/index.html.erb
@@ -8,12 +8,12 @@
 
 <div class="col-md-10 col-sm-12">
   <%= grid @grid do |g|
+    g.column(name: Adventure.human_attribute_name(:title), attribute: 'title', assoc: :translations, filter: false) do |a|
+      link_to(a.title, admin_adventure_adventure_missions_path(a))
+    end
     g.column(name: model_name(Introduction), attribute: 'title', assoc: :translations, filter: true) do |a|
         link_to(a.introduction.title, admin_introduction_path(a.introduction))
       end
-    g.column(name: Adventure.human_attribute_name(:title), attribute: 'title', assoc: :translations, filter: false) do |a|
-      link_to(a.title, edit_admin_adventure_path(a))
-    end
     g.column(name: Adventure.human_attribute_name(:start_date), attribute: 'start_date', filter: false)
     g.column(name: Adventure.human_attribute_name(:end_date), attribute: 'end_date', filter: false)
   end -%>

--- a/app/views/admin/adventures/new.html.erb
+++ b/app/views/admin/adventures/new.html.erb
@@ -5,5 +5,5 @@
 
   <%= render('form', adventure: @adventure) %>
   <hr>
-  <%= link_to(t('.all'), admin_adventures_path, class: 'btn secondary') %>
+  <%= link_to(t('.all'), admin_adventures_path(introduction: @introduction), class: 'btn secondary') %>
 </div>

--- a/app/views/admin/groups/adventures.html.erb
+++ b/app/views/admin/groups/adventures.html.erb
@@ -3,13 +3,20 @@
 </div>
 
 <div class="col-md-2 col-xs-12">
-  <%= link_to t('.all_groups'), admin_groups_path, class: 'btn secondary' %>
+  <%= link_to t('.all_groups'), admin_groups_path(introduction: @introduction), class: 'btn secondary' %>
+  <%= link_to t('.all_adventures'), admin_adventures_path(introduction: @introduction), class: 'btn secondary' %>
 </div>
 
 <div class="col-md-10 col-xs-12">
   <%= grid(@grid) do |g|
+      g.column(name: t('.adventure'), attribute: 'title', assoc: [:adventure_mission, :adventure, :translations], filter: false) do |amg|
+        amg.adventure_mission.adventure.title.truncate(40)
+      end
       g.column(name: t('.missions'), attribute: 'title', assoc: [:adventure_mission, :translations], filter: false) do |amg|
         amg.adventure_mission.title.truncate(40)
+      end
+      g.column(name: t('.completed_at'), attribute: 'created_at', filter: false) do |amg|
+        amg.created_at
       end
       g.column(name: t('.last_updated'), attribute: 'updated_at', filter: false) do |amg|
         amg.updated_at
@@ -21,7 +28,7 @@
         if amg.adventure_mission.locked? then t('global.yes') else t('global.no') end
       end
       g.column(filter: false) do |amg|
-        link_to t('.edit'), edit_admin_adventure_mission_group_path(amg)
+        link_to t('.edit'), edit_admin_group_adventure_mission_group_path(@group, amg)
       end
     end -%>
 </div>

--- a/app/views/admin/introductions/show.html.erb
+++ b/app/views/admin/introductions/show.html.erb
@@ -17,7 +17,7 @@
     </div>
   <% end %>
 
-  <%= link_to admin_adventures_path do %>
+  <%= link_to admin_adventures_path(introduction: @introduction) do %>
     <div class="col-md-2 col-sm-3 col-xs-12 box">
       <div class="interior"><%= icon('fas', 'trophy fa-4x') %></div>
       <div class="interior"><%= models_name(Adventure) %></div>

--- a/app/views/adventure_mission_groups/edit.html.erb
+++ b/app/views/adventure_mission_groups/edit.html.erb
@@ -9,7 +9,12 @@
         <%= simple_form_for(@adventure_mission_group) do |f| %>
           <%= f.input :points %>
           <%= f.input :adventure_mission_id, as: :hidden, input_html: { value: @adventure_mission.id }%>
-          <%= f.button :submit, value: t('.save') %>
+          <%= f.input :pending, as: :hidden, input_html: { value: @adventure_mission.require_acceptance }%>
+          <% if @adventure_mission.require_acceptance? and @adventure_mission.accepted?(@adventure_mission_group.group) %>
+            <%= f.button :submit, value: t('.save'), data: { confirm: t('.confirm_update') } %>
+          <% else %>
+            <%= f.button :submit, value: t('.save') %>
+          <% end %>
         <% end %>
       </li>
     </ul>

--- a/app/views/adventure_missions/show.html.erb
+++ b/app/views/adventure_missions/show.html.erb
@@ -20,20 +20,28 @@
     <%= AdventureMission.human_attribute_name(:max_points) %>
   </li>
 
-
-  <% if @adventure_mission_group.present? %>
+  <% if @adventure_mission.accepted?(@group) %>
     <% @class = 'success' %>
     <% @icon = 'check' %>
     <% @icon_prefix = 'fas' %>
+    <% @text = t('.finished') %>
+  <% elsif @adventure_mission_group.present? %>
+    <% @class = 'warning' %>
+    <% @icon = 'clock' %>
+    <% @icon_prefix = 'fas' %>
+    <% @text = t('.await_approval') %>
   <% else %>
     <% @class = 'danger' %>
     <% @icon = 'times' %>
     <% @icon_prefix = 'fas' %>
+    <% @text = t('.finished') %>
   <% end %>
+
   <li class="list-group-item list-group-item-<%= @class %>">
     <span class="badge"><%= icon(@icon_prefix, @icon) %></span>
-    <%= t('.finished') %>
+    <%= @text %>
   </li>
+
   <% if @adventure_mission_group.present? %>
     <li class="list-group-item">
       <span class="badge"><%= @adventure_mission_group.points %></span>
@@ -55,7 +63,9 @@
   <% if current_user.mentor? %>
     <% if @adventure_mission_group.nil? %>
       <% if @adventure_mission.variable_points? %>
-        <%= link_to t('.finish_mission'), new_adventure_mission_group_path(adventure_mission: @adventure_mission), method: 'get', class: 'btn primary' %>
+        <%= link_to t('.finish_mission'), new_adventure_mission_group_path(adventure_mission: @adventure_mission),
+                                          method: 'get',
+                                          class: 'btn primary' %>
       <% else %>
         <%= link_to t('.finish_mission'),
                     adventure_mission_groups_path(adventure_mission_group:
@@ -69,12 +79,17 @@
     <% else %>
       <% if !@adventure_mission.locked? %>
         <% if @adventure_mission.variable_points? %>
-          <%= link_to t('.update_points'), edit_adventure_mission_group_path(@adventure_mission_group), method: 'get', class: 'btn primary' %>
+          <%= link_to t('.update_points'), edit_adventure_mission_group_path(@adventure_mission_group),
+                                           method: 'get',
+                                           class: 'btn primary' %>
         <% end %>
-        <%= link_to t('.reset_points'), adventure_mission_group_path(@adventure_mission_group), method: 'delete', class: 'btn danger' %>
+        <%= link_to t('.reset'), adventure_mission_group_path(@adventure_mission_group),
+                                   method: 'delete',
+                                   class: 'btn danger pull-right',
+                                   data: { confirm: t('.confirm_destroy') } %>
       <% end %>
     <% end %>
-    <% end %>
+  <% end %>
     <%= link_to(t('adventures.show.index'), adventures_path, class: 'btn secondary') %>
 
 </div>

--- a/app/views/adventures/_adventure_view.html.erb
+++ b/app/views/adventures/_adventure_view.html.erb
@@ -34,17 +34,27 @@
                   a.title
                 end
 
-                g.column(name: AdventureMission.human_attribute_name(:max_points), attribute: 'max_points', filter: false, ordering: false)
                 g.column(name: t('.finished'), filter: true) do |a|
-                  if a.finished?(current_user.groups.regular.last) then t('global.yes') else t('global.no') end
+                  if a.finished?(@group) then t('global.yes') else t('global.no') end
                 end
 
-                g.column(name: AdventureMission.human_attribute_name(:locked), filter: true) do |a|
-                  if a.locked? then t('global.yes') else t('global.no') end
+                g.column(name: t('.accepted')) do |a|
+                  if a.accepted?(@group) then t('global.yes') else t('global.no') end
                 end
 
                 g.column(name: t('.points'), filter: false) do |a|
-                  a.points(current_user.groups.regular.last)
+                  amg = a.adventure_mission_groups.by_group(@group)
+                  if amg.empty?
+                    0
+                  else
+                    amg.first.points.to_i
+                  end
+                end
+
+                g.column(name: AdventureMission.human_attribute_name(:max_points), attribute: 'max_points', filter: false, ordering: false)
+
+                g.column(name: AdventureMission.human_attribute_name(:locked), filter: true) do |a|
+                  if a.locked? then t('global.yes') else t('global.no') end
                 end
 
                 g.column(name: '', filter: false) do |a|

--- a/config/locales/models/adventure_mission.sv.yml
+++ b/config/locales/models/adventure_mission.sv.yml
@@ -15,6 +15,7 @@ sv:
         max_points: Maxpoäng
         locked: Låst
         variable_points: Varierbar poäng
+        require_acceptance: Kräver godkännande
         publish_results: Publicera resultaten
         groups: Faddergrupper
         index: Nummer

--- a/config/locales/views/admin/adventure_mission_groups/adventure_mission_groups_admin.sv.yml
+++ b/config/locales/views/admin/adventure_mission_groups/adventure_mission_groups_admin.sv.yml
@@ -4,6 +4,9 @@ sv:
       index:
         accept_missions_for: Acceptera uppdrag för äventyr
         accept: Acceptera
+        await_acceptance: Väntar godkännande
+        accepted: Godkända
+        decline: Avböj
       edit:
         title: Redigera slutfört uppdrag
         confirm_destroy: Vill du verkligen förinta det slutförda uppdraget?
@@ -20,3 +23,6 @@ sv:
       accept:
         success: Uppdrag godkänt
         fail: Godkännande misslyckades
+      decline:
+        success: Uppdrag avböjt
+        fail: Kunde inte uppdatera det slutförda uppdraget

--- a/config/locales/views/admin/adventure_mission_groups/adventure_mission_groups_admin.sv.yml
+++ b/config/locales/views/admin/adventure_mission_groups/adventure_mission_groups_admin.sv.yml
@@ -1,15 +1,22 @@
 sv:
   admin:
     adventure_mission_groups:
+      index:
+        accept_missions_for: Acceptera uppdrag för äventyr
+        accept: Acceptera
       edit:
         title: Redigera slutfört uppdrag
         confirm_destroy: Vill du verkligen förinta det slutförda uppdraget?
         destroy: Förinta
         all: Alla slutförda uppdrag
         save: Spara
+        pending: Behöver fortfarande godkännas
       update:
         success: Slutfört uppdrag uppdaterad
         fail: Kunde inte uppdatera det slutförda uppdraget
       destroy:
         success: Slutfört uppdrag förintat
         fail: Kunde inte förinta det slutföra uppdraget
+      accept:
+        success: Uppdrag godkänt
+        fail: Godkännande misslyckades

--- a/config/locales/views/admin/adventure_missions/adventure_missions_admin.sv.yml
+++ b/config/locales/views/admin/adventure_missions/adventure_missions_admin.sv.yml
@@ -21,3 +21,5 @@ sv:
         add: Lägg till uppdrag
         lock: Lås alla uppdrag
         unlock: Lås upp alla uppdrag
+        acceptance: Godkännande
+        groups: Grupper

--- a/config/locales/views/admin/groups/groups_admin.sv.yml
+++ b/config/locales/views/admin/groups/groups_admin.sv.yml
@@ -24,8 +24,12 @@ sv:
 
       adventures:
         all_groups: Alla grupper
-        title: Äventyr för
+        all_adventures: Alla äventyr
+        title: Avklarade uppdrag av
         missions: Uppdrag
+        completed_at: Avklarat
         last_updated: Senast uppdaterad
         points: Poäng
         edit: Redigera
+        adventure: Äventyr
+        introduction: Nollning

--- a/config/locales/views/adventure_mission_groups/adventure_mission_groups.sv.yml
+++ b/config/locales/views/adventure_mission_groups/adventure_mission_groups.sv.yml
@@ -6,6 +6,7 @@ sv:
       update: Ändra poäng
       save: Spara poäng
       locked: Uppdraget är låst
+      confirm_update: Vill du verkligen uppdatera det slutförda uppdraget? Detta gör att uppdraget måste godkännas igen
     create:
       success: Uppdrag slutfört
       fail: Kunde inte slutföra uppdrag

--- a/config/locales/views/adventure_missions/adventure_missions.sv.yml
+++ b/config/locales/views/adventure_missions/adventure_missions.sv.yml
@@ -11,7 +11,9 @@ sv:
       points: Poäng
       finish_mission: Slutför uppdrag
       update_points: Uppdatera poäng
-      reset_points: Återställ poäng
       no_group: Du måste vara med i en faddergrupp för att göra detta
       locked: Äventyrsuppdraget är låst
       not_locked: Äventyrsuppdraget går att slutföra
+      reset: Återställ äventyrsuppdrag
+      await_approval: Väntar godkännande
+      confirm_destroy: Är du säker på att du vill ta bort uppdraget?

--- a/config/locales/views/adventures/adventures.sv.yml
+++ b/config/locales/views/adventures/adventures.sv.yml
@@ -26,3 +26,4 @@ sv:
       points: Poäng
       finished: Avklarat
       read_more: Läs mer/slutför uppdrag
+      accepted: Godkänt

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,9 +167,10 @@ Fsek::Application.routes.draw do
         patch :lock
         patch :unlock
         resources :adventure_missions, path: :aventyrsuppdrag
+        resources :adventure_mission_groups, path: :vantande_aventyrsuppdrag do
+          patch :accept
+        end
       end
-
-      resources :adventure_mission_groups, path: :avslutade_aventyrsuppdrag
     end
 
     resources :councils, path: :utskott, only: [:index, :show]
@@ -320,6 +321,7 @@ Fsek::Application.routes.draw do
     namespace :admin do
       resources :groups, path: :grupper, except: :show do
         get :adventures, path: :aventyr
+        resources :adventure_mission_groups
         resources :group_users, path: :anvandare, only: :index do
           patch :set_fadder, on: :member
           patch :set_not_fadder, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,8 +167,8 @@ Fsek::Application.routes.draw do
         patch :lock
         patch :unlock
         resources :adventure_missions, path: :aventyrsuppdrag
-        resources :adventure_mission_groups, path: :vantande_aventyrsuppdrag do
-          patch :accept
+        resources :adventure_mission_groups, path: :godkannande do
+          patch :accept, :decline
         end
       end
     end

--- a/db/migrate/20200729173400_add_pending_attributes_to_adventures.rb
+++ b/db/migrate/20200729173400_add_pending_attributes_to_adventures.rb
@@ -1,0 +1,8 @@
+class AddPendingAttributesToAdventures < ActiveRecord::Migration[5.0]
+  def change
+    add_column(:adventure_missions, :require_acceptance, :boolean, default: true, null: false)
+
+    # An existing record with pending: false is regarded completed and accepted
+    add_column(:adventure_mission_groups, :pending, :boolean, default: false, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190911162000) do
+ActiveRecord::Schema.define(version: 20200729173400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20190911162000) do
     t.integer "group_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "pending", default: false, null: false
     t.index ["adventure_mission_id", "group_id"], name: "index_adv_mission_groups_on_adm_mission_and_group", unique: true
     t.index ["adventure_mission_id"], name: "index_adventure_mission_groups_on_adventure_mission_id"
     t.index ["group_id"], name: "index_adventure_mission_groups_on_group_id"
@@ -72,6 +73,7 @@ ActiveRecord::Schema.define(version: 20190911162000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "locked", default: true, null: false
+    t.boolean "require_acceptance", default: true, null: false
     t.index ["adventure_id"], name: "index_adventure_missions_on_adventure_id"
   end
 


### PR DESCRIPTION
Backend implementation of pending adventure missions and admin pages for handling this. 
An AdventureMission now has an attribute 'require_acceptance' and an AdventureMissionGroup now has an attribute 'pending'. An AdventureMissionGroup that exists has been marked as finished by a mentor, whereas if pending also is false, it has been accepted by the Fös.

This PR does everything except the API in #1033 