### PR TITLE
Functionality for searching for target adress removed

### DIFF
--- a/app/models/mail_alias.rb
+++ b/app/models/mail_alias.rb
@@ -12,8 +12,8 @@ class MailAlias < ApplicationRecord
   scope :fulltext_search, -> (str) do
     (username, domain) = str.split('@', 2)
     if domain.present?
-      return where('(username = ? and domain = ?) or target = ?',
-                   username, domain, str)
+      return where('username = ? and domain = ?',
+                   username, domain)
     elsif username.present?
       return where('username like ?', "%#{username}%")
     else

--- a/spec/models/mail_alias_spec.rb
+++ b/spec/models/mail_alias_spec.rb
@@ -50,8 +50,6 @@ describe MailAlias do
       MailAlias.fulltext_search('jo').should == [ m1 ]
       MailAlias.fulltext_search('johannes').should == [ ]
       MailAlias.fulltext_search('erik').should == [ m2 ]
-      MailAlias.fulltext_search('johan@fsektionen.se').should == [ m1 ]
-      MailAlias.fulltext_search('jaforberg@gmail.com').should == [ m1 ]
     end
   end
 


### PR DESCRIPTION
The issue with accidental deleting is removed by the admin not being able to search for specific mail adress targets. Any search will always show all targets for the given aliases.