### PR TITLE
use google for smtp and show email errors

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,15 +78,16 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: PUBLIC_URL }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
 
   config.action_mailer.smtp_settings = {
-    address: '127.0.0.1',
-    port: 25,
-    domain: PUBLIC_URL,
+    address: 'smtp-relay.gmail.com',
+    port: 587,
+    domain: 'fsektionen.se',
     authentication: 'plain',
-    enable_starttls_auto: false
+    enable_starttls_auto: true,
+    openssl_verify_mode: 'none'
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -65,14 +65,16 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: PUBLIC_URL }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_caching = false
 
   config.action_mailer.smtp_settings = {
-    address: '127.0.0.1',
-    port: 25,
-    domain: PUBLIC_URL,
+    address: 'smtp-relay.gmail.com',
+    port: 587,
+    domain: 'fsektionen.se',
     authentication: 'plain',
-    enable_starttls_auto: false
+    enable_starttls_auto: true,
+    openssl_verify_mode: 'none'
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
uses gmail as smtp-server so contant-emails can come to gsuite mails and also use dkim, dmarc and ssl

also change so we know when contact mails fail to send.