### PR TITLE
Added a timer for the intermediate election. OBSERVE THAT THIS IS A BAD

### DIFF
--- a/app/views/elections/index.html.erb
+++ b/app/views/elections/index.html.erb
@@ -6,6 +6,13 @@
 </div>
 
 <div class="col-md-3 col-sm-12 election">
+  <div class="countdown row">
+    <p>Tid tills mellanliggande val stänger</p>
+    <div class="timer" data-format="%D dagar %H:%M:%S"
+                        data-time="<%=l(DateTime.parse("2022-11-19"),
+                                  format: '%Y/%m/%d %H:%M:%S %z')%>">
+    </div>
+  </div>
   <%= render 'countdown', election_view: @election_view %>
 
   <hr>


### PR DESCRIPTION
HARDCODED SOLUTION THAT SHOULD BE REMOVED AS SOON AS THE TIMER ENDS. I HAVE NO GUARANTEES THAT THIS WORKS PAST, OR EVEN UP TO, THE ELECTION CLOSES. THIS DOES NOT CHANGE THE ACTUAL TIME THE ELECTION CLOSES FOR THE INTERMEDIATE ELECTION, IT ONLY ADDS A TIMER FOR VISIBILITY. (hopefully the timer is set for the right date 🙂)