### PR TITLE
[API] (Update): Remove full user info from game_score_serializer

### DIFF
--- a/app/serializers/api/game_score_serializer.rb
+++ b/app/serializers/api/game_score_serializer.rb
@@ -1,12 +1,5 @@
 class Api::GameScoreSerializer <  ActiveModel::Serializer
   class Api::GameScoreSerializer::Index < ActiveModel::Serializer
-    attributes(:id, :user, :score)
-
-    def user
-      {
-        id: object.user.id,
-        game_nickname: object.user.game_nickname
-      }
-    end
+    attributes(:id, :name, :score)
   end
 end


### PR DESCRIPTION
This should restrict the information that can be requested from game_score_serializer to the same level as other parts of the API.